### PR TITLE
Remove PHP 5.x code and add support for PHP 7.4

### DIFF
--- a/jsonpath.c
+++ b/jsonpath.c
@@ -59,7 +59,7 @@ PHP_METHOD(JsonPath, find)
 	    strcpy(lex_tok_values[lex_tok_count], buffer);
 	    break;
         case LEX_ERR:
-            snprintf(err.msg, sizeof(err.msg), "%s at position %d", err.msg, (err.pos - path));
+            snprintf(err.msg, sizeof(err.msg), "%s at position %ld", err.msg, (err.pos - path));
             zend_throw_exception(spl_ce_RuntimeException, err.msg, 0 TSRMLS_CC);
             return;
 	default:
@@ -496,7 +496,9 @@ bool compare_rgxp(expr_operator * lh, expr_operator * rh)
     ZVAL_NULL(&retval);
     ZVAL_NULL(&subpats);
 
-    php_pcre_match_impl(pce, (*lh).value, strlen((*lh).value), &retval, &subpats, 0, 0, 0, 0);
+    zend_string *s_lh = zend_string_init((*lh).value, strlen((*lh).value), 0);
+
+    php_pcre_match_impl(pce, s_lh, &retval, &subpats, 0, 0, 0, 0);
 
     zval_ptr_dtor(&subpats);
     zval_ptr_dtor(&pattern);

--- a/src/jsonpath/lexer.c
+++ b/src/jsonpath/lexer.c
@@ -254,7 +254,7 @@ static bool extract_quoted_literal(char *p, char *buffer, size_t bufSize, lex_er
 
     if (jp_str_cpy(buffer, bufSize, start, cpy_len) > 0) {
         err->pos = p;
-        sprintf(err->msg, "String size exceeded %d bytes", bufSize);
+        sprintf(err->msg, "String size exceeded %ld bytes", bufSize);
         return false;
     }
 
@@ -278,7 +278,7 @@ static bool extract_unbounded_literal(char *p, char *buffer, size_t bufSize, lex
 
     if (jp_str_cpy(buffer, bufSize, start, cpy_len) > 0) {
         err->pos = p;
-        sprintf(err->msg, "String size exceeded %d bytes", bufSize);
+        sprintf(err->msg, "String size exceeded %ld bytes", bufSize);
         return false;
     }
 
@@ -302,7 +302,7 @@ static bool extract_unbounded_numeric_literal(char *p, char *buffer, size_t bufS
 
     if (jp_str_cpy(buffer, bufSize, start, cpy_len) > 0) {
         err->pos = p;
-        sprintf(err->msg, "String size exceeded %d bytes", bufSize);
+        sprintf(err->msg, "String size exceeded %ld bytes", bufSize);
         return false;
     }
 


### PR DESCRIPTION
- Remove all `if/else` blocks that deal with PHP 5.x
- Minor tweaks to get the code compiling in PHP 7.4, most notably `php_pcre_match_impl()` interface changes