### PR TITLE
Add negative indexes, step parameter, and default values for array slicing

### DIFF
--- a/src/jsonpath/lexer.c
+++ b/src/jsonpath/lexer.c
@@ -213,6 +213,16 @@ lex_token scan(char **p, char *buffer, size_t bufSize, lex_error * err)
 	case '*':
 	    found_token = LEX_WILD_CARD;
 	    break;
+	case '-':
+		if (!isdigit(*(*p + 1))) {
+			return LEX_ERR;
+		}
+		if (!extract_unbounded_numeric_literal(*p, buffer, bufSize, err)) {
+                return LEX_ERR;
+            }
+	    *p += strlen(buffer) - 1;
+	    found_token = LEX_LITERAL;
+	    break;
 	case '0':
 	case '1':
 	case '2':
@@ -295,6 +305,10 @@ static bool extract_unbounded_numeric_literal(char *p, char *buffer, size_t bufS
     for (; *p != '\0' && *p == ' '; p++);
 
     start = p;
+
+	if (*p == '-') {
+		p++;
+	}
 
     for (; isdigit(*p); p++);
 

--- a/src/jsonpath/parser.c
+++ b/src/jsonpath/parser.c
@@ -159,6 +159,7 @@ bool build_parse_tree(
 ) {
 
     int i = 0, x = 0, z = 0, expr_count = 0;
+	int slice_counter = 0;
     int *int_ptr;
 
     for (i = 0; i < lex_tok_count; i++) {
@@ -208,6 +209,7 @@ bool build_parse_tree(
 	    } else if (lex_tok[i + 1] == LEX_FILTER_START) {
 		i += 2;
 		z = 0;
+		slice_counter = 0;
 		//TODO What if only 1 element, make sure type doesn't change
 		tok[x].filter_type = FLTR_INDEX;
 		while (lex_tok[i] != LEX_EXPR_END) {
@@ -215,6 +217,18 @@ bool build_parse_tree(
 			tok[x].filter_type = FLTR_INDEX;
 		    } else if (lex_tok[i] == LEX_SLICE) {
 			tok[x].filter_type = FLTR_RANGE;
+			slice_counter++;
+			// [:a] => [0:a]
+			// [a::] => [a:0:]
+			if (slice_counter > tok[x].index_count) {
+				if (slice_counter == 1) {
+					tok[x].indexes[z] = 0;
+				} else if (slice_counter == 2) {
+					tok[x].indexes[z] = 0;
+				}
+				tok[x].index_count++;
+				z++;
+			}
 		    } else if (lex_tok[i] == LEX_WILD_CARD) {
 			tok[x].filter_type = FLTR_WILD_CARD;
 		    } else if (lex_tok[i] == LEX_LITERAL) {


### PR DESCRIPTION
Adds various improvements to the array slice expression:
- Negative indexes to reference elements from the end of the list, for example `-1` to reference the last element
- Step parameter, for example `[0:5:2]` to target the first, third and fifth element in an array
- Start, end, and step are all optional, with the following defaults:
    - start: `0`, beginning of list
    - end: `0`, end of list, inclusive
    - step: `1`
- Examples: `[1:]` to skip the first element, `[0:-2]` to skip the last two elements, `[::3]` to pick every third element