### PR TITLE
Parse literal booleans separately for more accurate comparisons, add rudimentary support for wildcard operator with recursive descent

### DIFF
--- a/src/jsonpath/lexer.h
+++ b/src/jsonpath/lexer.h
@@ -24,6 +24,7 @@ typedef enum {
     LEX_PAREN_OPEN,		/* ( */
     LEX_PAREN_CLOSE,		/* ) */
     LEX_LITERAL,		/* "some string" 'some string' */
+    LEX_LITERAL_BOOL,   /* true, false */
     LEX_FILTER_START,		/* [ */
     LEX_AND,			/* && */
     LEX_OR,			/* || */

--- a/src/jsonpath/parser.h
+++ b/src/jsonpath/parser.h
@@ -39,9 +39,10 @@ typedef enum {
     EXPR_PAREN_LEFT,		//9
     EXPR_PAREN_RIGHT,		//10
     EXPR_LITERAL,		//11
-    EXPR_BOOL,			//12
-    EXPR_NODE_NAME,		//13
-    EXPR_RGXP                   //14
+    EXPR_LITERAL_BOOL,  //12
+    EXPR_BOOL,			//13
+    EXPR_NODE_NAME,		//14
+    EXPR_RGXP                   //15
 } expr_op_type;
 
 typedef struct {


### PR DESCRIPTION
- Dirty hack to support boolean `true` and `false` in filter expressions, for example `$.store.book[?(@.in_stock == true)]`
- Rudimentary support for wildcard with recursive descent, `$..*` to return all leaf nodes in the JSON structure