### PR TITLE
Fix some initialization and read-after-release errors found with the debugger

### DIFF
--- a/jsonpath.c
+++ b/jsonpath.c
@@ -240,7 +240,7 @@ void processChildKey(zval * arr, operator * tok, operator * tok_last, zval * ret
 	    // For each array entry, find the node names and populate their values
 	    // Fill up expression NODE_NAME VALS
 	    for (x = 0; x < tok->expression_count; x++) {
-		if (tok->expressions[x + 1].type == EXPR_ISSET) {
+		if (x < tok->expression_count - 1 && tok->expressions[x + 1].type == EXPR_ISSET) {
 		    if (!checkIfKeyExists(data2, &tok->expressions[x])) {
 			continue;
 		    }
@@ -413,9 +413,9 @@ bool compare_lt(expr_operator * lh, expr_operator * rh)
     ZVAL_STRING(&a, (*lh).value);
     ZVAL_STRING(&b, (*rh).value);
 
+    compare_function(&result, &a, &b);
     zval_ptr_dtor(&a);
     zval_ptr_dtor(&b);
-    compare_function(&result, &a, &b);
 
     bool res = (Z_LVAL(result) < 0);
 
@@ -429,9 +429,9 @@ bool compare_gt(expr_operator * lh, expr_operator * rh)
     ZVAL_STRING(&a, (*lh).value);
     ZVAL_STRING(&b, (*rh).value);
 
+    compare_function(&result, &a, &b);
     zval_ptr_dtor(&a);
     zval_ptr_dtor(&b);
-    compare_function(&result, &a, &b);
 
     bool res = (Z_LVAL(result) > 0);
 
@@ -445,9 +445,9 @@ bool compare_lte(expr_operator * lh, expr_operator * rh)
     ZVAL_STRING(&a, (*lh).value);
     ZVAL_STRING(&b, (*rh).value);
 
+    compare_function(&result, &a, &b);
     zval_ptr_dtor(&a);
     zval_ptr_dtor(&b);
-    compare_function(&result, &a, &b);
 
     bool res = (Z_LVAL(result) <= 0);
 
@@ -461,9 +461,9 @@ bool compare_gte(expr_operator * lh, expr_operator * rh)
     ZVAL_STRING(&a, (*lh).value);
     ZVAL_STRING(&b, (*rh).value);
 
+    compare_function(&result, &a, &b);
     zval_ptr_dtor(&a);
     zval_ptr_dtor(&b);
-    compare_function(&result, &a, &b);
 
     bool res = (Z_LVAL(result) >= 0);
 
@@ -487,9 +487,9 @@ bool compare_eq(expr_operator * lh, expr_operator * rh)
     ZVAL_STRING(&a, (*lh).value);
     ZVAL_STRING(&b, (*rh).value);
 
+    compare_function(&result, &a, &b);
     zval_ptr_dtor(&a);
     zval_ptr_dtor(&b);
-    compare_function(&result, &a, &b);
 
     bool res = (Z_LVAL(result) == 0);
 
@@ -503,9 +503,9 @@ bool compare_neq(expr_operator * lh, expr_operator * rh)
     ZVAL_STRING(&a, (*lh).value);
     ZVAL_STRING(&b, (*rh).value);
 
+    compare_function(&result, &a, &b);
     zval_ptr_dtor(&a);
     zval_ptr_dtor(&b);
-    compare_function(&result, &a, &b);
 
     bool res = (Z_LVAL(result) != 0);
 

--- a/src/jsonpath/parser.c
+++ b/src/jsonpath/parser.c
@@ -182,6 +182,9 @@ bool build_parse_tree(
 
     for (i = 0; i < lex_tok_count; i++) {
 
+		// Initialize to sentinel value
+		tok[x].filter_type = -1;
+
 	switch (lex_tok[i]) {
 
 	case ROOT:


### PR DESCRIPTION
Debugger output examples:

```
==1349069== Conditional jump or move depends on uninitialised value(s)
==1349069==    at 0x484CE5B: zim_JsonPath_find (jsonpath.c:97)
==1349069==    by 0x67DCD5: ZEND_DO_FCALL_SPEC_RETVAL_USED_HANDLER (zend_vm_execute.h:1863)
==1349069==    by 0x6ED1D7: execute_ex (zend_vm_execute.h:54560)
==1349069==    by 0x6F2924: zend_execute (zend_vm_execute.h:58875)
==1349069==    by 0x643968: zend_execute_scripts (zend.c:1680)
==1349069==    by 0x5A4F4B: php_execute_script (main.c:2488)
==1349069==    by 0x733028: do_cli (php_cli.c:949)
==1349069==    by 0x734076: main (php_cli.c:1336)
==1349069==  Uninitialised value was created by a stack allocation
==1349069==    at 0x484CB42: zim_JsonPath_find (jsonpath.c:31)
```

```
==1354633== Invalid read of size 1
==1354633==    at 0x484221D: bcmp (in /usr/lib/x86_64-linux-gnu/valgrind/vgpreload_memcheck-amd64-linux.so)
==1354633==    by 0x63D130: zend_binary_strcmp (zend_operators.c:2691)
==1354633==    by 0x63DABA: zendi_smart_strcmp (zend_operators.c:2919)
==1354633==    by 0x63AACF: zend_compare (zend_operators.c:2099)
==1354633==    by 0x63A4FA: compare_function (zend_operators.c:2002)
==1354633==    by 0x484E6D2: compare_eq (jsonpath.c:492)
==1354633==    by 0x4850BBE: evaluate_postfix_expression (parser.c:342)
==1354633==    by 0x484D95B: processChildKey (jsonpath.c:254)
==1354633==    by 0x484CFFF: iterate (jsonpath.c:128)
==1354633==    by 0x484D74D: processChildKey (jsonpath.c:234)
==1354633==    by 0x484CFFF: iterate (jsonpath.c:128)
==1354633==    by 0x484CFB1: iterate (jsonpath.c:119)
==1354633==  Address 0x4e1fa68 is 24 bytes inside a block of size 40 free'd
==1354633==    at 0x483CA3F: free (in /usr/lib/x86_64-linux-gnu/valgrind/vgpreload_memcheck-amd64-linux.so)
==1354633==    by 0x607B68: _efree_custom (zend_alloc.c:2427)
==1354633==    by 0x607CBF: _efree (zend_alloc.c:2547)
==1354633==    by 0x63F569: zend_string_destroy (zend_variables.c:67)
==1354633==    by 0x63F466: rc_dtor_func (zend_variables.c:57)
==1354633==    by 0x63F3E5: i_zval_ptr_dtor (zend_variables.h:44)
==1354633==    by 0x63F609: zval_ptr_dtor (zend_variables.c:84)
==1354633==    by 0x484E6BB: compare_eq (jsonpath.c:491)
==1354633==    by 0x4850BBE: evaluate_postfix_expression (parser.c:342)
==1354633==    by 0x484D95B: processChildKey (jsonpath.c:254)
==1354633==    by 0x484CFFF: iterate (jsonpath.c:128)
==1354633==    by 0x484D74D: processChildKey (jsonpath.c:234)
==1354633==  Block was alloc'd at
==1354633==    at 0x483B7F3: malloc (in /usr/lib/x86_64-linux-gnu/valgrind/vgpreload_memcheck-amd64-linux.so)
==1354633==    by 0x608E5C: __zend_malloc (zend_alloc.c:3030)
==1354633==    by 0x607AF7: _malloc_custom (zend_alloc.c:2418)
==1354633==    by 0x607C41: _emalloc (zend_alloc.c:2537)
==1354633==    by 0x484C999: zend_string_alloc (zend_string.h:141)
==1354633==    by 0x484CA0C: zend_string_init (zend_string.h:163)
==1354633==    by 0x484E689: compare_eq (jsonpath.c:488)
==1354633==    by 0x4850BBE: evaluate_postfix_expression (parser.c:342)
==1354633==    by 0x484D95B: processChildKey (jsonpath.c:254)
==1354633==    by 0x484CFFF: iterate (jsonpath.c:128)
==1354633==    by 0x484D74D: processChildKey (jsonpath.c:234)
==1354633==    by 0x484CFFF: iterate (jsonpath.c:128)
```