### PR TITLE
Test the build with PHP nightly (8.1) as well

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,7 +14,7 @@ jobs:
         strategy:
             fail-fast: false
             matrix:
-                php: [7.4, 8.0]
+                php: [7.4, 8.0, 8.1]
                 use-opcache: [true, false]
 
         steps:


### PR DESCRIPTION
Although PHP 8.1 isn't released yet, it's good to be aware of any issues beforehand.