### PR TITLE
Fix compile warning about implicit function declaration of get_operator_precedence()

### DIFF
--- a/src/jsonpath/parser.c
+++ b/src/jsonpath/parser.c
@@ -5,6 +5,7 @@
 #include "safe_string.h"
 
 bool is_unary(expr_op_type);
+int get_operator_precedence(expr_op_type type);
 
 // Return node count (not including last token)
 


### PR DESCRIPTION
Fixes this warning:

```
.../jsonpath/src/jsonpath/parser.c: In function ‘convert_to_postfix’:
.../jsonpath/src/jsonpath/parser.c:400:9: warning: implicit declaration of function ‘get_operator_precedence’ [-Wimplicit-function-declaration]
  400 |     if (get_operator_precedence(expr_in[i].type) > get_operator_precedence((*expr_tmp).type)) {
      |         ^~~~~~~~~~~~~~~~~~~~~~~
```