### PR TITLE
Add support for range filtering on root node

### DIFF
--- a/jsonpath.c
+++ b/jsonpath.c
@@ -122,7 +122,12 @@ void iterate(zval* arr, operator * tok, operator * tok_last, zval* return_value)
 
     switch (tok->type) {
     case ROOT:
-        iterate(arr, (tok + 1), tok_last, return_value);
+        if (tok->filter_type == FLTR_RANGE) {
+            processChildKey(arr, tok, tok_last, return_value);
+        }
+        else {
+            iterate(arr, (tok + 1), tok_last, return_value);
+        }
         break;
     case WILD_CARD:
         iterateWildCard(arr, tok, tok_last, return_value);

--- a/src/jsonpath/parser.c
+++ b/src/jsonpath/parser.c
@@ -189,18 +189,18 @@ bool build_parse_tree(
 
 		switch (lex_tok[i]) {
 
-		case ROOT:
-			tok[x].type = ROOT;
-			x++;
-			break;
 		case LEX_WILD_CARD:
 			tok[x].type = WILD_CARD;
 			x++;
 			break;
+		case ROOT:
 		case LEX_DEEP_SCAN:
 		case LEX_NODE:
 
-			if (lex_tok[i] == LEX_DEEP_SCAN) {
+			if (lex_tok[i] == ROOT) {
+				tok[x].type = ROOT;
+			}
+			else if (lex_tok[i] == LEX_DEEP_SCAN) {
 				tok[x].type = DEEP_SCAN;
 				i++;
 			}


### PR DESCRIPTION
This makes it possible to use array slicing on the root node, for example `$[0:10:2]` to get every second element of the first 10 elements in the array.