### PR TITLE
misc: replace ulong with zend_ulong

### DIFF
--- a/jsonpath.c
+++ b/jsonpath.c
@@ -169,7 +169,7 @@ void processChildKey(zval* arr, operator * tok, operator * tok_last, zval* retur
 
     int x;
     zend_string* key;
-    ulong num_key;
+    zend_ulong num_key;
     int range_start = 0;
     int range_end = 0;
     int range_step = 1;
@@ -296,7 +296,7 @@ void iterateWildCard(zval* arr, operator * tok, operator * tok_last, zval* retur
     zval* data;
     zval* zv_dest;
     zend_string* key;
-    ulong num_key;
+    zend_ulong num_key;
 
     ZEND_HASH_FOREACH_KEY_VAL(HASH_OF(arr), num_key, key, data) {
         if (tok == tok_last) {
@@ -320,7 +320,7 @@ void recurse(zval* arr, operator * tok, operator * tok_last, zval* return_value)
     zval* data;
     zval* zv_dest;
     zend_string* key;
-    ulong num_key;
+    zend_ulong num_key;
 
     ZEND_HASH_FOREACH_KEY_VAL(HASH_OF(arr), num_key, key, data) {
         recurse(data, tok, tok_last, return_value);


### PR DESCRIPTION
I got the following compilation error under PHP 7.4 on MacOS Mojave:

```
/Users/mike/dev/php-ext-jsonpath/jsonpath.c:172:5: error: use of undeclared identifier 'ulong'
    ulong num_key;
```

Looks like this is due to a breaking change in PHP 7.4.

See [the PHP 7.4 internals upgrade notes](https://github.com/php/php-src/blob/PHP-7.4/UPGRADING.INTERNALS#L24).