### PR TITLE
misc: fix array out of bounds bug

### DIFF
--- a/jsonpath.c
+++ b/jsonpath.c
@@ -18,6 +18,7 @@
 
 /* True global resources - no need for thread safety here */
 static int le_jsonpath;
+bool scanTokens(char* json_path, lex_token tok[], char tok_literals[][PARSE_BUF_LEN], int* tok_count);
 void iterate(zval* arr, operator * tok, operator * tok_last, zval* return_value);
 void recurse(zval* arr, operator * tok, operator * tok_last, zval* return_value);
 bool findByValue(zval* arr, expr_operator* node);
@@ -36,73 +37,46 @@ zend_class_entry* jsonpath_ce;
 
 PHP_METHOD(JsonPath, find)
 {
-    char* path;
-    size_t path_len;
-    zval* z_array;
-    HashTable* arr;
+    /* parse php method parameters */
 
-    if (zend_parse_parameters(ZEND_NUM_ARGS(), "as", &z_array, &path, &path_len) == FAILURE) {
+    char* j_path;
+    size_t j_path_len;
+    zval* search_target;
+
+    if (zend_parse_parameters(ZEND_NUM_ARGS(), "as", &search_target, &j_path, &j_path_len) == FAILURE) {
         return;
     }
 
-    array_init(return_value);
+    /* tokenize JSON-path string */
 
     lex_token lex_tok[PARSE_BUF_LEN];
-    char lex_tok_values[PARSE_BUF_LEN][PARSE_BUF_LEN];
+    char lex_tok_literals[PARSE_BUF_LEN][PARSE_BUF_LEN];
     int lex_tok_count = 0;
 
-    char* p = path;
-
-    char buffer[PARSE_BUF_LEN];
-
-    lex_token* ptr = lex_tok;
-
-    lex_error err;
-
-    while ((*ptr = scan(&p, buffer, sizeof(buffer), &err)) != LEX_NOT_FOUND) {
-
-        lex_tok_count++;
-
-        if (lex_tok_count > PARSE_BUF_LEN) {
-            zend_throw_exception(spl_ce_RuntimeException, "The query is too long. Token count exceeds PARSE_BUF_LEN.", 0);
-            return;
-        }
-
-        switch (*ptr) {
-        case LEX_NODE:
-        case LEX_LITERAL:
-        case LEX_LITERAL_BOOL:
-            strcpy(lex_tok_values[lex_tok_count-1], buffer);
-            break;
-        case LEX_ERR:
-            snprintf(err.msg, sizeof(err.msg), "%s at position %ld", err.msg, (err.pos - path));
-            zend_throw_exception(spl_ce_RuntimeException, err.msg, 0);
-            return;
-        default:
-            lex_tok_values[lex_tok_count-1][0] = '\0';
-            break;
-        }
-
-        ptr++;
+    if (!scanTokens(j_path, lex_tok, lex_tok_literals, &lex_tok_count)) {
+        return;
     }
+
+    /* assemble an array of query execution instructions from parsed tokens */
 
     operator tok[PARSE_BUF_LEN];
     int tok_count = 0;
-    int* int_ptr = &tok_count;
-
     parse_error p_err;
 
-    if (!build_parse_tree(lex_tok, lex_tok_values, lex_tok_count, tok, int_ptr, &p_err)) {
+    if (!build_parse_tree(lex_tok, lex_tok_literals, lex_tok_count, tok, &tok_count, &p_err)) {
         zend_throw_exception(spl_ce_RuntimeException, p_err.msg, 0);
     }
 
-    operator * tok_ptr_start;
-    operator * tok_ptr_end;
+    /* execute the JSON-path query instructions against the search target (PHP object/array) */
 
-    tok_ptr_start = &tok[0];
-    tok_ptr_end = &tok[tok_count - 1];
+    operator * tok_ptr_start = &tok[0];
+    operator * tok_ptr_end = &tok[tok_count - 1];
 
-    iterate(z_array, tok_ptr_start, tok_ptr_end, return_value);
+    array_init(return_value);
+
+    iterate(search_target, tok_ptr_start, tok_ptr_end, return_value);
+
+    /* free the memory allocated for filter expressions */
 
     operator * fr = tok_ptr_start;
 
@@ -113,12 +87,55 @@ PHP_METHOD(JsonPath, find)
         fr++;
     }
 
+    /* return false if no results were found by the JSON-path query */
+
     if (zend_hash_num_elements(HASH_OF(return_value)) == 0) {
         convert_to_boolean(return_value);
         RETURN_FALSE;
     }
 
     return;
+}
+
+bool scanTokens(char* json_path, lex_token tok[], char tok_literals[][PARSE_BUF_LEN], int* tok_count)
+{
+    lex_token cur_tok;
+    char* p = json_path;
+    char buffer[PARSE_BUF_LEN];
+    lex_error err;
+
+    int i = 0;
+
+    while ((cur_tok = scan(&p, buffer, sizeof(buffer), &err)) != LEX_NOT_FOUND) {
+
+        if (i >= PARSE_BUF_LEN) {
+            zend_throw_exception(spl_ce_RuntimeException,
+                "The query is too long. Token count exceeds PARSE_BUF_LEN.", 0);
+            return false;
+        }
+
+        switch (cur_tok) {
+        case LEX_NODE:
+        case LEX_LITERAL:
+        case LEX_LITERAL_BOOL:
+            strcpy(tok_literals[i], buffer);
+            break;
+        case LEX_ERR:
+            snprintf(err.msg, sizeof(err.msg), "%s at position %ld", err.msg, (err.pos - json_path));
+            zend_throw_exception(spl_ce_RuntimeException, err.msg, 0);
+            return false;
+        default:
+            tok_literals[i][0] = '\0';
+            break;
+        }
+
+        tok[i] = cur_tok;
+        i++;
+    }
+
+    *tok_count = i;
+
+    return true;
 }
 
 void iterate(zval* arr, operator * tok, operator * tok_last, zval* return_value)

--- a/tests/overflow/002.phpt
+++ b/tests/overflow/002.phpt
@@ -1,0 +1,17 @@
+--TEST--
+Ensure queries that contain more than PARSE_BUF_LEN tokens safely fail
+--SKIPIF--
+<?php if (!extension_loaded("jsonpath")) print "skip"; ?>
+--FILE--
+<?php
+
+$jsonPath = new JsonPath();
+
+try {
+    // This query contains 51 tokens (root selector $ plus 50 dot selectors), which exceeds PARSE_BUF_LEN
+    var_dump($jsonPath->find([], '$.1.2.3.4.5.6.7.8.9.10.11.12.13.14.15.16.17.18.19.20.21.22.23.24.25.26.27.28.29.30.31.32.33.34.35.36.37.38.39.40.41.42.43.44.45.46.47.48.49.50'));
+} catch(RuntimeException $e) {
+    echo get_class($e) . ": " . $e->getMessage();
+}
+--EXPECT--
+RuntimeException: The query is too long. Token count exceeds PARSE_BUF_LEN.


### PR DESCRIPTION
Parsed tokens are copied to an array of fixed length `PARSE_BUF_LEN`. The token scan routine fails if more than `PARSE_BUF_LEN` tokens are parsed because there is no bounds check.

In the future, the scan routine should probably be refactored to copy tokens into a dynamically-sized array.

**Update**
I also took the opportunity to decompose and clean up the `find()` method a bit.