### PR TITLE
Add bracket notation tests from JSONPath Comparison, allow index lookups on root, make sure start and end quotes match 

### DIFF
--- a/jsonpath.c
+++ b/jsonpath.c
@@ -123,7 +123,7 @@ void iterate(zval* arr, operator * tok, operator * tok_last, zval* return_value)
 
     switch (tok->type) {
     case ROOT:
-        if (tok->filter_type == FLTR_RANGE) {
+        if (tok->filter_type == FLTR_RANGE || tok->filter_type == FLTR_INDEX) {
             processChildKey(arr, tok, tok_last, return_value);
         }
         else {

--- a/jsonpath.c
+++ b/jsonpath.c
@@ -158,12 +158,15 @@ void processChildKey(zval* arr, operator * tok, operator * tok_last, zval* retur
         return;
     }
 
-    // FLTR_WILD_CARD doesn't necessarily target a specific node. E.g. $..[*] should loop through the
-    // whole array.
-    // TODO: Check if we need to deal with empty string as array key
-    if (tok->node_value_len == 0) {
+    // Sometimes we want to loop through the whole array. Examples:
+    // $..[*]
+    // $[0:6]
+    if (tok->node_value_len == 0 && (tok->type == ROOT || tok->type == DEEP_SCAN)) {
         data = arr;
     }
+    // And sometimes we're interested only in a particular key. Examples:
+    // $['somekey']
+    // $.somekey
     else if ((data = zend_hash_str_find(HASH_OF(arr), tok->node_value, tok->node_value_len)) == NULL) {
         return;
     }

--- a/src/jsonpath/lexer.c
+++ b/src/jsonpath/lexer.c
@@ -265,15 +265,23 @@ static bool extract_quoted_literal(char* p, char* buffer, size_t bufSize, lex_er
 {
 	char* start;
 	char quote_type;
+	bool quote_found = false;
 	size_t cpy_len;
 
 	for (; *p != '\0' && (*p == '\'' || *p == '"' || *p == ' '); p++) {
 		// Find first occurrence
 		if (*p == '\'' || *p == '"') {
+			quote_found = true;
 			quote_type = *p;
 			p++;
 			break;
 		}
+	}
+
+	if (quote_found == false) {
+		err->pos = p;
+		strcpy(err->msg, "Missing opening quote in string literal");
+		return false;
 	}
 
 	start = p;

--- a/src/jsonpath/lexer.c
+++ b/src/jsonpath/lexer.c
@@ -267,7 +267,13 @@ static bool extract_quoted_literal(char* p, char* buffer, size_t bufSize, lex_er
 	char* start;
 	size_t cpy_len;
 
-	for (; *p != '\0' && (*p == '\'' || *p == '"' || *p == ' '); p++);
+	for (; *p != '\0' && (*p == '\'' || *p == '"' || *p == ' '); p++) {
+		// Find first occurrence
+		if (*p == '\'' || *p == '"') {
+			p++;
+			break;
+		}
+	}
 
 	start = p;
 

--- a/src/jsonpath/lexer.c
+++ b/src/jsonpath/lexer.c
@@ -260,16 +260,17 @@ lex_token scan(char** p, char* buffer, size_t bufSize, lex_error* err)
 	return found_token;
 }
 
-/* Extract contents of string bounded by single or double quotes */
+/* Extract contents of string bounded by either single or double quotes */
 static bool extract_quoted_literal(char* p, char* buffer, size_t bufSize, lex_error* err)
 {
-
 	char* start;
+	char quote_type;
 	size_t cpy_len;
 
 	for (; *p != '\0' && (*p == '\'' || *p == '"' || *p == ' '); p++) {
 		// Find first occurrence
 		if (*p == '\'' || *p == '"') {
+			quote_type = *p;
 			p++;
 			break;
 		}
@@ -277,7 +278,7 @@ static bool extract_quoted_literal(char* p, char* buffer, size_t bufSize, lex_er
 
 	start = p;
 
-	for (; *p != '\0' && (*p != '\'' && *p != '"'); p++);
+	for (; *p != '\0' && *p != quote_type && *(p - 1) != '\\'; p++);
 
 	cpy_len = (size_t)(p - start);
 

--- a/src/jsonpath/parser.c
+++ b/src/jsonpath/parser.c
@@ -233,6 +233,11 @@ bool build_parse_tree(
 				}
 			}
 			else if (lex_tok[i + 1] == LEX_FILTER_START) {
+				if (lex_tok[i + 2] == LEX_EXPR_END) {
+					strncpy(err->msg, "Filter must not be empty", sizeof(err->msg));
+					return false;
+				}
+
 				i += 2;
 				z = 0;
 				slice_counter = 0;

--- a/tests/comparison_bracket_notation/001.phpt
+++ b/tests/comparison_bracket_notation/001.phpt
@@ -1,0 +1,23 @@
+--TEST--
+Test bracket notation
+--SKIPIF--
+<?php if (!extension_loaded("jsonpath")) print "skip"; ?>
+--FILE--
+<?php
+
+$data = [
+    "key" => "value",
+];
+
+$jsonPath = new JsonPath();
+$result = $jsonPath->find($data, "$['key']");
+
+echo "Assertion 1\n";
+var_dump($result);
+?>
+--EXPECT--
+Assertion 1
+array(1) {
+  [0]=>
+  string(5) "value"
+}

--- a/tests/comparison_bracket_notation/002.phpt
+++ b/tests/comparison_bracket_notation/002.phpt
@@ -1,0 +1,20 @@
+--TEST--
+Test bracket notation on object without key
+--SKIPIF--
+<?php if (!extension_loaded("jsonpath")) print "skip"; ?>
+--FILE--
+<?php
+
+$data = [
+    "key" => "value",
+];
+
+$jsonPath = new JsonPath();
+$result = $jsonPath->find($data, "$['missing']");
+
+echo "Assertion 1\n";
+var_dump($result);
+?>
+--EXPECT--
+Assertion 1
+bool(false)

--- a/tests/comparison_bracket_notation/003.phpt
+++ b/tests/comparison_bracket_notation/003.phpt
@@ -1,0 +1,60 @@
+--TEST--
+Test bracket notation after recursive descent
+--SKIPIF--
+<?php if (!extension_loaded("jsonpath")) print "skip"; ?>
+--FILE--
+<?php
+
+$data = [
+    "first",
+    [
+        "key" => [
+            "first nested",
+            [
+                "more" => [
+                    [
+                        "nested" => [
+                            "deepest",
+                            "second",
+                        ],
+                    ],
+                    [
+                        "more",
+                        "values",
+                    ],
+                ],
+            ],
+        ],
+    ],
+];
+
+$jsonPath = new JsonPath();
+$result = $jsonPath->find($data, '$..[0]');
+
+echo "Assertion 1\n";
+var_dump($result);
+?>
+--EXPECT--
+Assertion 1
+array(5) {
+  [0]=>
+  string(7) "deepest"
+  [1]=>
+  string(12) "first nested"
+  [2]=>
+  string(5) "first"
+  [3]=>
+  string(4) "more"
+  [4]=>
+  array(1) {
+    ["nested"]=>
+    array(2) {
+      [0]=>
+      string(7) "deepest"
+      [1]=>
+      string(6) "second"
+    }
+  }
+}
+--XFAIL--
+Requires more work on the recursive descent implementation

--- a/tests/comparison_bracket_notation/004.phpt
+++ b/tests/comparison_bracket_notation/004.phpt
@@ -1,0 +1,20 @@
+--TEST--
+Test bracket notation with NFC path on NFD key
+--SKIPIF--
+<?php if (!extension_loaded("jsonpath")) print "skip"; ?>
+--FILE--
+<?php
+
+$data = [
+    "ü" => 42,
+];
+
+$jsonPath = new JsonPath();
+$result = $jsonPath->find($data, "$['ü']");
+
+echo "Assertion 1\n";
+var_dump($result);
+?>
+--EXPECT--
+Assertion 1
+bool(false)

--- a/tests/comparison_bracket_notation/005.phpt
+++ b/tests/comparison_bracket_notation/005.phpt
@@ -1,0 +1,30 @@
+--TEST--
+Test bracket notation with dot
+--SKIPIF--
+<?php if (!extension_loaded("jsonpath")) print "skip"; ?>
+--FILE--
+<?php
+
+$data = [
+    "one" => [
+        "key" => "value",
+    ],
+    "two" => [
+        "some" => "more",
+        "key" => "other value",
+    ],
+    "two.some" => 42,
+];
+
+$jsonPath = new JsonPath();
+$result = $jsonPath->find($data, "$['two.some']");
+
+echo "Assertion 1\n";
+var_dump($result);
+?>
+--EXPECT--
+Assertion 1
+array(1) {
+  [0]=>
+  int(42)
+}

--- a/tests/comparison_bracket_notation/006.phpt
+++ b/tests/comparison_bracket_notation/006.phpt
@@ -1,0 +1,23 @@
+--TEST--
+Test bracket notation with double quotes
+--SKIPIF--
+<?php if (!extension_loaded("jsonpath")) print "skip"; ?>
+--FILE--
+<?php
+
+$data = [
+    "key" => "value",
+];
+
+$jsonPath = new JsonPath();
+$result = $jsonPath->find($data, '$["key"]');
+
+echo "Assertion 1\n";
+var_dump($result);
+?>
+--EXPECT--
+Assertion 1
+array(1) {
+  [0]=>
+  string(5) "value"
+}

--- a/tests/comparison_bracket_notation/007.phpt
+++ b/tests/comparison_bracket_notation/007.phpt
@@ -1,0 +1,25 @@
+--TEST--
+Test bracket notation with empty path
+--SKIPIF--
+<?php if (!extension_loaded("jsonpath")) print "skip"; ?>
+--FILE--
+<?php
+
+$data = [
+    "" => 42,
+    "''" => 123,
+    "\"\"" => 222,
+];
+
+$jsonPath = new JsonPath();
+$result = $jsonPath->find($data, '$[]');
+
+echo "Assertion 1\n";
+var_dump($result);
+?>
+--EXPECTF--
+Fatal error: Uncaught RuntimeException: Filter must not be empty in %s007.php:%d
+Stack trace:
+#0 %s007.php(%d): JsonPath->find(Array, '$[]')
+#1 {main}
+  thrown in %s007.php on line %d

--- a/tests/comparison_bracket_notation/008.phpt
+++ b/tests/comparison_bracket_notation/008.phpt
@@ -1,0 +1,25 @@
+--TEST--
+Test bracket notation with empty string
+--SKIPIF--
+<?php if (!extension_loaded("jsonpath")) print "skip"; ?>
+--FILE--
+<?php
+
+$data = [
+    "" => 42,
+    "''" => 123,
+    "\"\"" => 222,
+];
+
+$jsonPath = new JsonPath();
+$result = $jsonPath->find($data, "$['']");
+
+echo "Assertion 1\n";
+var_dump($result);
+?>
+--EXPECT--
+Assertion 1
+array(1) {
+  [0]=>
+  int(42)
+}

--- a/tests/comparison_bracket_notation/009.phpt
+++ b/tests/comparison_bracket_notation/009.phpt
@@ -1,0 +1,25 @@
+--TEST--
+Test bracket notation with empty string doubled quoted
+--SKIPIF--
+<?php if (!extension_loaded("jsonpath")) print "skip"; ?>
+--FILE--
+<?php
+
+$data = [
+    "" => 42,
+    "''" => 123,
+    "\"\"" => 222,
+];
+
+$jsonPath = new JsonPath();
+$result = $jsonPath->find($data, '$[""]');
+
+echo "Assertion 1\n";
+var_dump($result);
+?>
+--EXPECT--
+Assertion 1
+array(1) {
+  [0]=>
+  int(42)
+}

--- a/tests/comparison_bracket_notation/010.phpt
+++ b/tests/comparison_bracket_notation/010.phpt
@@ -1,0 +1,20 @@
+--TEST--
+Test bracket notation with negative number on short array
+--SKIPIF--
+<?php if (!extension_loaded("jsonpath")) print "skip"; ?>
+--FILE--
+<?php
+
+$data = [
+    "one element",
+];
+
+$jsonPath = new JsonPath();
+$result = $jsonPath->find($data, '$[-2]');
+
+echo "Assertion 1\n";
+var_dump($result);
+?>
+--EXPECT--
+Assertion 1
+bool(false)

--- a/tests/comparison_bracket_notation/011.phpt
+++ b/tests/comparison_bracket_notation/011.phpt
@@ -1,0 +1,27 @@
+--TEST--
+Test bracket notation with number
+--SKIPIF--
+<?php if (!extension_loaded("jsonpath")) print "skip"; ?>
+--FILE--
+<?php
+
+$data = [
+    "first",
+    "second",
+    "third",
+    "forth",
+    "fifth",
+];
+
+$jsonPath = new JsonPath();
+$result = $jsonPath->find($data, '$[2]');
+
+echo "Assertion 1\n";
+var_dump($result);
+?>
+--EXPECT--
+Assertion 1
+array(1) {
+  [0]=>
+  string(5) "third"
+}

--- a/tests/comparison_bracket_notation/012.phpt
+++ b/tests/comparison_bracket_notation/012.phpt
@@ -1,0 +1,23 @@
+--TEST--
+Test bracket notation with number on object
+--SKIPIF--
+<?php if (!extension_loaded("jsonpath")) print "skip"; ?>
+--FILE--
+<?php
+
+$data = [
+    "0" => "value",
+];
+
+$jsonPath = new JsonPath();
+$result = $jsonPath->find($data, '$[0]');
+
+echo "Assertion 1\n";
+var_dump($result);
+?>
+--EXPECT--
+Assertion 1
+array(1) {
+  [0]=>
+  string(5) "value"
+}

--- a/tests/comparison_bracket_notation/013.phpt
+++ b/tests/comparison_bracket_notation/013.phpt
@@ -1,0 +1,20 @@
+--TEST--
+Test bracket notation with number on short array
+--SKIPIF--
+<?php if (!extension_loaded("jsonpath")) print "skip"; ?>
+--FILE--
+<?php
+
+$data = [
+    "one element",
+];
+
+$jsonPath = new JsonPath();
+$result = $jsonPath->find($data, '$[1]');
+
+echo "Assertion 1\n";
+var_dump($result);
+?>
+--EXPECT--
+Assertion 1
+bool(false)

--- a/tests/comparison_bracket_notation/014.phpt
+++ b/tests/comparison_bracket_notation/014.phpt
@@ -1,0 +1,21 @@
+--TEST--
+Test bracket notation with number on string
+--SKIPIF--
+<?php if (!extension_loaded("jsonpath")) print "skip"; ?>
+--FILE--
+<?php
+
+$data = "Hello World";
+
+$jsonPath = new JsonPath();
+$result = $jsonPath->find($data, '$[0]');
+
+echo "Assertion 1\n";
+var_dump($result);
+?>
+--EXPECTF--
+Fatal error: Uncaught TypeError: JsonPath::find(): Argument #1 ($data) must be of type array, string given in %s014.php:%d
+Stack trace:
+#0 %s014.php(%d): JsonPath->find('Hello World', '$[0]')
+#1 {main}
+  thrown in %s014.php on line %d

--- a/tests/comparison_bracket_notation/014_php7.phpt
+++ b/tests/comparison_bracket_notation/014_php7.phpt
@@ -2,6 +2,7 @@
 Test bracket notation with number on string
 --SKIPIF--
 <?php if (!extension_loaded("jsonpath")) print "skip"; ?>
+<?php if (version_compare(PHP_VERSION, '8.0.0', '>=')) print "skip"; ?>
 --FILE--
 <?php
 
@@ -14,8 +15,6 @@ echo "Assertion 1\n";
 var_dump($result);
 ?>
 --EXPECTF--
-Fatal error: Uncaught TypeError: JsonPath::find(): Argument #1 ($data) must be of type array, string given in %s014.php:%d
-Stack trace:
-#0 %s014.php(%d): JsonPath->find('Hello World', '$[0]')
-#1 {main}
-  thrown in %s014.php on line %d
+Warning: JsonPath::find() expects parameter 1 to be array, string given in %s014_php7.php on line %d
+Assertion 1
+NULL

--- a/tests/comparison_bracket_notation/014_php8.phpt
+++ b/tests/comparison_bracket_notation/014_php8.phpt
@@ -1,0 +1,22 @@
+--TEST--
+Test bracket notation with number on string
+--SKIPIF--
+<?php if (!extension_loaded("jsonpath")) print "skip"; ?>
+<?php if (version_compare(PHP_VERSION, '8.0.0', '<')) print "skip"; ?>
+--FILE--
+<?php
+
+$data = "Hello World";
+
+$jsonPath = new JsonPath();
+$result = $jsonPath->find($data, '$[0]');
+
+echo "Assertion 1\n";
+var_dump($result);
+?>
+--EXPECTF--
+Fatal error: Uncaught TypeError: JsonPath::find(): Argument #1 ($data) must be of type array, string given in %s014_php8.php:%d
+Stack trace:
+#0 %s014_php8.php(%d): JsonPath->find('Hello World', '$[0]')
+#1 {main}
+  thrown in %s014_php8.php on line %d

--- a/tests/comparison_bracket_notation/015.phpt
+++ b/tests/comparison_bracket_notation/015.phpt
@@ -1,0 +1,31 @@
+--TEST--
+Test bracket notation with number after dot notation with wildcard on nested arrays with different length
+--SKIPIF--
+<?php if (!extension_loaded("jsonpath")) print "skip"; ?>
+--FILE--
+<?php
+
+$data = [
+    [
+        1,
+    ],
+    [
+        2,
+        3,
+    ],
+];
+
+$jsonPath = new JsonPath();
+$result = $jsonPath->find($data, '$.*[1]');
+
+echo "Assertion 1\n";
+var_dump($result);
+?>
+--EXPECT--
+Assertion 1
+array[1]{
+  [0]=>
+  int(3)
+}
+--XFAIL--
+Requires filter expression support in wildcard iteration

--- a/tests/comparison_bracket_notation/015.phpt
+++ b/tests/comparison_bracket_notation/015.phpt
@@ -28,4 +28,4 @@ array[1]{
   int(3)
 }
 --XFAIL--
-Requires filter expression support in wildcard iteration
+Requires filter handling in wildcard iteration

--- a/tests/comparison_bracket_notation/016.phpt
+++ b/tests/comparison_bracket_notation/016.phpt
@@ -1,0 +1,25 @@
+--TEST--
+Test bracket notation with number -1
+--SKIPIF--
+<?php if (!extension_loaded("jsonpath")) print "skip"; ?>
+--FILE--
+<?php
+
+$data = [
+    "first",
+    "second",
+    "third",
+];
+
+$jsonPath = new JsonPath();
+$result = $jsonPath->find($data, '$[-1]');
+
+echo "Assertion 1\n";
+var_dump($result);
+?>
+--EXPECT--
+Assertion 1
+array(1) {
+  [0]=>
+  string(5) "third"
+}

--- a/tests/comparison_bracket_notation/017.phpt
+++ b/tests/comparison_bracket_notation/017.phpt
@@ -1,0 +1,18 @@
+--TEST--
+Test bracket notation with number -1 on empty array
+--SKIPIF--
+<?php if (!extension_loaded("jsonpath")) print "skip"; ?>
+--FILE--
+<?php
+
+$data = [];
+
+$jsonPath = new JsonPath();
+$result = $jsonPath->find($data, '$[-1]');
+
+echo "Assertion 1\n";
+var_dump($result);
+?>
+--EXPECT--
+Assertion 1
+bool(false)

--- a/tests/comparison_bracket_notation/018.phpt
+++ b/tests/comparison_bracket_notation/018.phpt
@@ -1,0 +1,27 @@
+--TEST--
+Test bracket notation with number 0
+--SKIPIF--
+<?php if (!extension_loaded("jsonpath")) print "skip"; ?>
+--FILE--
+<?php
+
+$data = [
+    "first",
+    "second",
+    "third",
+    "forth",
+    "fifth",
+];
+
+$jsonPath = new JsonPath();
+$result = $jsonPath->find($data, '$[0]');
+
+echo "Assertion 1\n";
+var_dump($result);
+?>
+--EXPECT--
+Assertion 1
+array(1) {
+  [0]=>
+  string(5) "first"
+}

--- a/tests/comparison_bracket_notation/019.phpt
+++ b/tests/comparison_bracket_notation/019.phpt
@@ -1,0 +1,24 @@
+--TEST--
+Test bracket notation with quoted array slice literal
+--SKIPIF--
+<?php if (!extension_loaded("jsonpath")) print "skip"; ?>
+--FILE--
+<?php
+
+$data = [
+    ":" => "value",
+    "another" => "entry",
+];
+
+$jsonPath = new JsonPath();
+$result = $jsonPath->find($data, "$[':']");
+
+echo "Assertion 1\n";
+var_dump($result);
+?>
+--EXPECT--
+Assertion 1
+array(1) {
+  [0]=>
+  string(5) "value"
+}

--- a/tests/comparison_bracket_notation/020.phpt
+++ b/tests/comparison_bracket_notation/020.phpt
@@ -1,0 +1,23 @@
+--TEST--
+Test bracket notation with quoted closing bracket literal
+--SKIPIF--
+<?php if (!extension_loaded("jsonpath")) print "skip"; ?>
+--FILE--
+<?php
+
+$data = [
+    "]" => 42,
+];
+
+$jsonPath = new JsonPath();
+$result = $jsonPath->find($data, "$[']']");
+
+echo "Assertion 1\n";
+var_dump($result);
+?>
+--EXPECT--
+Assertion 1
+array(1) {
+  [0]=>
+  int(42)
+}

--- a/tests/comparison_bracket_notation/021.phpt
+++ b/tests/comparison_bracket_notation/021.phpt
@@ -1,0 +1,24 @@
+--TEST--
+Test bracket notation with quoted current object literal
+--SKIPIF--
+<?php if (!extension_loaded("jsonpath")) print "skip"; ?>
+--FILE--
+<?php
+
+$data = [
+    "@" => "value",
+    "another" => "entry",
+];
+
+$jsonPath = new JsonPath();
+$result = $jsonPath->find($data, "$['@']");
+
+echo "Assertion 1\n";
+var_dump($result);
+?>
+--EXPECT--
+Assertion 1
+array(1) {
+  [0]=>
+  string(5) "value"
+}

--- a/tests/comparison_bracket_notation/022.phpt
+++ b/tests/comparison_bracket_notation/022.phpt
@@ -1,0 +1,24 @@
+--TEST--
+Test bracket notation with quoted dot literal
+--SKIPIF--
+<?php if (!extension_loaded("jsonpath")) print "skip"; ?>
+--FILE--
+<?php
+
+$data = [
+    "." => "value",
+    "another" => "entry",
+];
+
+$jsonPath = new JsonPath();
+$result = $jsonPath->find($data, "$['.']");
+
+echo "Assertion 1\n";
+var_dump($result);
+?>
+--EXPECT--
+Assertion 1
+array(1) {
+  [0]=>
+  string(5) "value"
+}

--- a/tests/comparison_bracket_notation/023.phpt
+++ b/tests/comparison_bracket_notation/023.phpt
@@ -1,0 +1,25 @@
+--TEST--
+Test bracket notation with quoted dot wildcard
+--SKIPIF--
+<?php if (!extension_loaded("jsonpath")) print "skip"; ?>
+--FILE--
+<?php
+
+$data = [
+    "key" => 42,
+    ".*" => 1,
+    "" => 10,
+];
+
+$jsonPath = new JsonPath();
+$result = $jsonPath->find($data, "$['.*']");
+
+echo "Assertion 1\n";
+var_dump($result);
+?>
+--EXPECT--
+Assertion 1
+array(1) {
+  [0]=>
+  int(1)
+}

--- a/tests/comparison_bracket_notation/024.phpt
+++ b/tests/comparison_bracket_notation/024.phpt
@@ -1,0 +1,24 @@
+--TEST--
+Test bracket notation with quoted double quote literal
+--SKIPIF--
+<?php if (!extension_loaded("jsonpath")) print "skip"; ?>
+--FILE--
+<?php
+
+$data = [
+    "\"" => "value",
+    "another" => "entry",
+];
+
+$jsonPath = new JsonPath();
+$result = $jsonPath->find($data, "$['\"']");
+
+echo "Assertion 1\n";
+var_dump($result);
+?>
+--EXPECT--
+Assertion 1
+array(1) {
+  [0]=>
+  string(5) "value"
+}

--- a/tests/comparison_bracket_notation/025.phpt
+++ b/tests/comparison_bracket_notation/025.phpt
@@ -1,0 +1,23 @@
+--TEST--
+Test bracket notation with quoted escaped backslash
+--SKIPIF--
+<?php if (!extension_loaded("jsonpath")) print "skip"; ?>
+--FILE--
+<?php
+
+$data = [
+    "\\" => "value",
+];
+
+$jsonPath = new JsonPath();
+$result = $jsonPath->find($data, "$['\\']");
+
+echo "Assertion 1\n";
+var_dump($result);
+?>
+--EXPECT--
+Assertion 1
+array(1) {
+  [0]=>
+  string(5) "value"
+}

--- a/tests/comparison_bracket_notation/026.phpt
+++ b/tests/comparison_bracket_notation/026.phpt
@@ -1,0 +1,23 @@
+--TEST--
+Test bracket notation with quoted escaped single quote
+--SKIPIF--
+<?php if (!extension_loaded("jsonpath")) print "skip"; ?>
+--FILE--
+<?php
+
+$data = [
+    "'" => "value",
+];
+
+$jsonPath = new JsonPath();
+$result = $jsonPath->find($data, '$["\'"]');
+
+echo "Assertion 1\n";
+var_dump($result);
+?>
+--EXPECT--
+Assertion 1
+array(1) {
+  [0]=>
+  string(5) "value"
+}

--- a/tests/comparison_bracket_notation/027.phpt
+++ b/tests/comparison_bracket_notation/027.phpt
@@ -1,0 +1,25 @@
+--TEST--
+Test bracket notation with quoted number on object
+--SKIPIF--
+<?php if (!extension_loaded("jsonpath")) print "skip"; ?>
+--FILE--
+<?php
+
+$data = [
+    "0" => "value",
+];
+
+$jsonPath = new JsonPath();
+$result = $jsonPath->find($data, "$['0']");
+
+echo "Assertion 1\n";
+var_dump($result);
+?>
+--EXPECT--
+Assertion 1
+array(1) {
+  [0]=>
+  string(5) "value"
+}
+--XFAIL--
+Numbers as strings need to be converted to integers in index lookups

--- a/tests/comparison_bracket_notation/028.phpt
+++ b/tests/comparison_bracket_notation/028.phpt
@@ -1,0 +1,24 @@
+--TEST--
+Test bracket notation with quoted root literal
+--SKIPIF--
+<?php if (!extension_loaded("jsonpath")) print "skip"; ?>
+--FILE--
+<?php
+
+$data = [
+    "$" => "value",
+    "another" => "entry",
+];
+
+$jsonPath = new JsonPath();
+$result = $jsonPath->find($data, "$['$']");
+
+echo "Assertion 1\n";
+var_dump($result);
+?>
+--EXPECT--
+Assertion 1
+array(1) {
+  [0]=>
+  string(5) "value"
+}

--- a/tests/comparison_bracket_notation/029.phpt
+++ b/tests/comparison_bracket_notation/029.phpt
@@ -1,0 +1,25 @@
+--TEST--
+Test bracket notation with quoted special characters combined
+--SKIPIF--
+<?php if (!extension_loaded("jsonpath")) print "skip"; ?>
+--FILE--
+<?php
+
+$data = [
+    ":@.\"$,*'\\" => 42,
+];
+
+$jsonPath = new JsonPath();
+$result = $jsonPath->find($data, "$[':@.\"$,*\'\\\\']");
+
+echo "Assertion 1\n";
+var_dump($result);
+?>
+--EXPECT--
+Assertion 1
+array(1) {
+  [0]=>
+  int(42)
+}
+--XFAIL--
+Requires changes to accommodate for quoted single-quotes

--- a/tests/comparison_bracket_notation/030.phpt
+++ b/tests/comparison_bracket_notation/030.phpt
@@ -1,0 +1,23 @@
+--TEST--
+Test bracket notation with quoted string and unescaped single quote
+--SKIPIF--
+<?php if (!extension_loaded("jsonpath")) print "skip"; ?>
+--FILE--
+<?php
+
+$data = [
+    "single'quote" => "value",
+];
+
+$jsonPath = new JsonPath();
+$result = $jsonPath->find($data, "$['single'quote']");
+
+echo "Assertion 1\n";
+var_dump($result);
+?>
+--EXPECTF--
+Fatal error: Uncaught RuntimeException: Missing closing ] bracket at position %d in %s030.php:%d
+Stack trace:
+#0 %s030.php(%d): JsonPath->find(Array, '$['single'quote...')
+#1 {main}
+  thrown in %s030.php on line %d

--- a/tests/comparison_bracket_notation/031.phpt
+++ b/tests/comparison_bracket_notation/031.phpt
@@ -1,0 +1,24 @@
+--TEST--
+Test bracket notation with quoted union literal
+--SKIPIF--
+<?php if (!extension_loaded("jsonpath")) print "skip"; ?>
+--FILE--
+<?php
+
+$data = [
+    "," => "value",
+    "another" => "entry",
+];
+
+$jsonPath = new JsonPath();
+$result = $jsonPath->find($data, "$[',']");
+
+echo "Assertion 1\n";
+var_dump($result);
+?>
+--EXPECT--
+Assertion 1
+array(1) {
+  [0]=>
+  string(5) "value"
+}

--- a/tests/comparison_bracket_notation/032.phpt
+++ b/tests/comparison_bracket_notation/032.phpt
@@ -1,0 +1,24 @@
+--TEST--
+Test bracket notation with quoted wildcard literal
+--SKIPIF--
+<?php if (!extension_loaded("jsonpath")) print "skip"; ?>
+--FILE--
+<?php
+
+$data = [
+    "*" => "value",
+    "another" => "entry",
+];
+
+$jsonPath = new JsonPath();
+$result = $jsonPath->find($data, "$['*']");
+
+echo "Assertion 1\n";
+var_dump($result);
+?>
+--EXPECT--
+Assertion 1
+array(1) {
+  [0]=>
+  string(5) "value"
+}

--- a/tests/comparison_bracket_notation/033.phpt
+++ b/tests/comparison_bracket_notation/033.phpt
@@ -1,0 +1,20 @@
+--TEST--
+Test bracket notation with quoted wildcard literal on object without key
+--SKIPIF--
+<?php if (!extension_loaded("jsonpath")) print "skip"; ?>
+--FILE--
+<?php
+
+$data = [
+    "another" => "entry",
+];
+
+$jsonPath = new JsonPath();
+$result = $jsonPath->find($data, "$['*']");
+
+echo "Assertion 1\n";
+var_dump($result);
+?>
+--EXPECT--
+Assertion 1
+bool(false)

--- a/tests/comparison_bracket_notation/034.phpt
+++ b/tests/comparison_bracket_notation/034.phpt
@@ -1,0 +1,31 @@
+--TEST--
+Test bracket notation with spaces
+--SKIPIF--
+<?php if (!extension_loaded("jsonpath")) print "skip"; ?>
+--FILE--
+<?php
+
+$data = [
+    " a" => 1,
+    "a" => 2,
+    " a " => 3,
+    "a " => 4,
+    " 'a' " => 5,
+    " 'a" => 6,
+    "a' " => 7,
+    " \"a\" " => 8,
+    "\"a\"" => 9,
+];
+
+$jsonPath = new JsonPath();
+$result = $jsonPath->find($data, "$[ 'a' ]");
+
+echo "Assertion 1\n";
+var_dump($result);
+?>
+--EXPECT--
+Assertion 1
+array(1) {
+  [0]=>
+  int(2)
+}

--- a/tests/comparison_bracket_notation/035.phpt
+++ b/tests/comparison_bracket_notation/035.phpt
@@ -1,0 +1,25 @@
+--TEST--
+Test bracket notation with string including dot wildcard
+--SKIPIF--
+<?php if (!extension_loaded("jsonpath")) print "skip"; ?>
+--FILE--
+<?php
+
+$data = [
+    "nice" => 42,
+    "ni.*" => 1,
+    "mice" => 100,
+];
+
+$jsonPath = new JsonPath();
+$result = $jsonPath->find($data, "$['ni.*']");
+
+echo "Assertion 1\n";
+var_dump($result);
+?>
+--EXPECT--
+Assertion 1
+array(1) {
+  [0]=>
+  int(1)
+}

--- a/tests/comparison_bracket_notation/036.phpt
+++ b/tests/comparison_bracket_notation/036.phpt
@@ -1,0 +1,31 @@
+--TEST--
+Test bracket notation with two literals separated by dot
+--SKIPIF--
+<?php if (!extension_loaded("jsonpath")) print "skip"; ?>
+--FILE--
+<?php
+
+$data = [
+    "one" => [
+        "key" => "value",
+    ],
+    "two" => [
+        "some" => "more",
+        "key" => "other value",
+    ],
+    "two.some" => "42",
+    "two'.'some" => "43",
+];
+
+$jsonPath = new JsonPath();
+$result = $jsonPath->find($data, "$['two'.'some']");
+
+echo "Assertion 1\n";
+var_dump($result);
+?>
+--EXPECTF--
+Fatal error: Uncaught RuntimeException: Missing closing ] bracket at position 7 in %s036.php:%d
+Stack trace:
+#0 %s036.php(%d): JsonPath->find(Array, '$['two'.'some']')
+#1 {main}
+  thrown in %s036.php on line %d

--- a/tests/comparison_bracket_notation/037.phpt
+++ b/tests/comparison_bracket_notation/037.phpt
@@ -1,0 +1,30 @@
+--TEST--
+Test bracket notation with two literals separated by dot without quotes
+--SKIPIF--
+<?php if (!extension_loaded("jsonpath")) print "skip"; ?>
+--FILE--
+<?php
+
+$data = [
+    "one" => [
+        "key" => "value",
+    ],
+    "two" => [
+        "some" => "more",
+        "key" => "other value",
+    ],
+    "two.some" => "42",
+];
+
+$jsonPath = new JsonPath();
+$result = $jsonPath->find($data, "$[two.some]");
+
+echo "Assertion 1\n";
+var_dump($result);
+?>
+--EXPECTF--
+Fatal error: Uncaught RuntimeException: Missing filter end ] in %s037.php:%d
+Stack trace:
+#0 %s037.php(%d): JsonPath->find(Array, '$[two.some]')
+#1 {main}
+  thrown in %s037.php on line %d

--- a/tests/comparison_bracket_notation/038.phpt
+++ b/tests/comparison_bracket_notation/038.phpt
@@ -1,0 +1,47 @@
+--TEST--
+Test bracket notation with wildcard on array
+--SKIPIF--
+<?php if (!extension_loaded("jsonpath")) print "skip"; ?>
+--FILE--
+<?php
+
+$data = [
+    "string",
+    42,
+    [
+        "key" => "value",
+    ],
+    [
+        0,
+        1,
+    ],
+];
+
+$jsonPath = new JsonPath();
+$result = $jsonPath->find($data, "$[*]");
+
+echo "Assertion 1\n";
+var_dump($result);
+?>
+--EXPECT--
+Assertion 1
+array(4) {
+  [0]=>
+  string(6) "string"
+  [1]=>
+  int(42)
+  [2]=>
+  array(1) {
+    ["key"]=>
+    string(5) "value"
+  }
+  [3]=>
+  array(2) {
+    [0]=>
+    int(0)
+    [1]=>
+    int(1)
+  }
+}
+--XFAIL--
+Requires more work on the wildcard iteration

--- a/tests/comparison_bracket_notation/039.phpt
+++ b/tests/comparison_bracket_notation/039.phpt
@@ -1,0 +1,18 @@
+--TEST--
+Test bracket notation with wildcard on empty array
+--SKIPIF--
+<?php if (!extension_loaded("jsonpath")) print "skip"; ?>
+--FILE--
+<?php
+
+$data = [];
+
+$jsonPath = new JsonPath();
+$result = $jsonPath->find($data, "$[*]");
+
+echo "Assertion 1\n";
+var_dump($result);
+?>
+--EXPECT--
+Assertion 1
+bool(false)

--- a/tests/comparison_bracket_notation/040.phpt
+++ b/tests/comparison_bracket_notation/040.phpt
@@ -1,0 +1,18 @@
+--TEST--
+Test bracket notation with wildcard on empty object
+--SKIPIF--
+<?php if (!extension_loaded("jsonpath")) print "skip"; ?>
+--FILE--
+<?php
+
+$data = [];
+
+$jsonPath = new JsonPath();
+$result = $jsonPath->find($data, "$[*]");
+
+echo "Assertion 1\n";
+var_dump($result);
+?>
+--EXPECT--
+Assertion 1
+bool(false)

--- a/tests/comparison_bracket_notation/041.phpt
+++ b/tests/comparison_bracket_notation/041.phpt
@@ -1,0 +1,31 @@
+--TEST--
+Test bracket notation with wildcard on null value array
+--SKIPIF--
+<?php if (!extension_loaded("jsonpath")) print "skip"; ?>
+--FILE--
+<?php
+
+$data = [
+    40,
+    null,
+    42,
+];
+
+$jsonPath = new JsonPath();
+$result = $jsonPath->find($data, "$[*]");
+
+echo "Assertion 1\n";
+var_dump($result);
+?>
+--EXPECT--
+Assertion 1
+array(3) {
+  [0]=>
+  int(40)
+  [1]=>
+  NULL
+  [2]=>
+  int(42)
+}
+--XFAIL--
+Requires more work on the wildcard iteration

--- a/tests/comparison_bracket_notation/042.phpt
+++ b/tests/comparison_bracket_notation/042.phpt
@@ -1,0 +1,47 @@
+--TEST--
+Test bracket notation with wildcard on object
+--SKIPIF--
+<?php if (!extension_loaded("jsonpath")) print "skip"; ?>
+--FILE--
+<?php
+
+$data = [
+    "some" => "string",
+    "int" => 42,
+    "object" => [
+        "key" => "value",
+    ],
+    "array" => [
+        0,
+        1,
+    ],
+];
+
+$jsonPath = new JsonPath();
+$result = $jsonPath->find($data, "$[*]");
+
+echo "Assertion 1\n";
+var_dump($result);
+?>
+--EXPECT--
+Assertion 1
+array(4) {
+  ["some"]=>
+  string(6) "string"
+  ["int"]=>
+  int(42)
+  ["object"]=>
+  array(1) {
+    ["key"]=>
+    string(5) "value"
+  }
+  ["array"]=>
+  array(2) {
+    [0]=>
+    int(0)
+    [1]=>
+    int(1)
+  }
+}
+--XFAIL--
+Requires more work on the wildcard iteration

--- a/tests/comparison_bracket_notation/043.phpt
+++ b/tests/comparison_bracket_notation/043.phpt
@@ -1,0 +1,40 @@
+--TEST--
+Test bracket notation with wildcard after array slice
+--SKIPIF--
+<?php if (!extension_loaded("jsonpath")) print "skip"; ?>
+--FILE--
+<?php
+
+$data = [
+    [
+        1,
+        2,
+    ],
+    [
+        "a",
+        "b",
+    ],
+    [
+        0,
+        0,
+    ],
+];
+
+$jsonPath = new JsonPath();
+$result = $jsonPath->find($data, "$[0:2][*]");
+
+echo "Assertion 1\n";
+var_dump($result);
+?>
+--EXPECT--
+Assertion 1
+array(4) {
+  [0]=>
+  int(1)
+  [1]=>
+  int(2)
+  [2]=>
+  string(1) "a"
+  [3]=>
+  string(1) "b"
+}

--- a/tests/comparison_bracket_notation/044.phpt
+++ b/tests/comparison_bracket_notation/044.phpt
@@ -1,0 +1,29 @@
+--TEST--
+Test bracket notation with wildcard after dot notation after bracket notation with wildcard
+--SKIPIF--
+<?php if (!extension_loaded("jsonpath")) print "skip"; ?>
+--FILE--
+<?php
+
+$data = [
+    [
+        "bar" => [
+            42,
+        ],
+    ],
+];
+
+$jsonPath = new JsonPath();
+$result = $jsonPath->find($data, "$[*].bar[*]");
+
+echo "Assertion 1\n";
+var_dump($result);
+?>
+--EXPECT--
+Assertion 1
+array(1) {
+  [0]=>
+  int(42)
+}
+--XFAIL--
+Requires more work on the wildcard iteration

--- a/tests/comparison_bracket_notation/045.phpt
+++ b/tests/comparison_bracket_notation/045.phpt
@@ -1,0 +1,55 @@
+--TEST--
+Test bracket notation with wildcard after dot notation after bracket notation with wildcard
+--SKIPIF--
+<?php if (!extension_loaded("jsonpath")) print "skip"; ?>
+--FILE--
+<?php
+
+$data = [
+    "key" => "value",
+    "another key" => [
+        "complex" => "string",
+        "primitives" => [
+            0,
+            1,
+        ],
+    ],
+];
+
+$jsonPath = new JsonPath();
+$result = $jsonPath->find($data, "$..[*]");
+
+echo "Assertion 1\n";
+var_dump($result);
+?>
+--EXPECT--
+Assertion 1
+array(6) {
+  [0]=>
+  string(5) "value"
+  [1]=>
+  array(2) {
+    ["complex"]=>
+    string(6) "string"
+    ["primitives"]=>
+    array(2) {
+      [0]=>
+      int(0)
+      [1]=>
+      int(1)
+    }
+  }
+  [2]=>
+  string(6) "string"
+  [3]=>
+  array(2) {
+    [0]=>
+    int(0)
+    [1]=>
+    int(1)
+  }
+  [4]=>
+  int(0)
+  [5]=>
+  int(1)
+}

--- a/tests/comparison_bracket_notation/046.phpt
+++ b/tests/comparison_bracket_notation/046.phpt
@@ -1,0 +1,23 @@
+--TEST--
+Test bracket notation without quotes
+--SKIPIF--
+<?php if (!extension_loaded("jsonpath")) print "skip"; ?>
+--FILE--
+<?php
+
+$data = [
+    "key" => "value",
+];
+
+$jsonPath = new JsonPath();
+$result = $jsonPath->find($data, "$[key]");
+
+echo "Assertion 1\n";
+var_dump($result);
+?>
+--EXPECTF--
+Fatal error: Uncaught RuntimeException: Filter must not be empty in %s046.php:%d
+Stack trace:
+#0 %s046.php(%d): JsonPath->find(Array, '$[key]')
+#1 {main}
+  thrown in %s046.php on line %d


### PR DESCRIPTION
Adds the 46 bracket notation tests from [JSONPath Comparison](https://cburgmer.github.io/json-path-comparison/), using the consensus result where there is one, and something that seems logical where there isn't consensus.

Changes:
- Stricter lexing of quoted strings – make sure that the quotation mark types (single / double quote) of the start and end quotes match
- Support index lookups on root level (for example `$[4]`)
- Rudimentary support for escaped quotes within quotes (needs a more robust permanent implementation)