### PR TITLE
Fix valgrind errors

### DIFF
--- a/src/jsonpath/parser.c
+++ b/src/jsonpath/parser.c
@@ -46,12 +46,14 @@ static bool tokenize_expression(
 
 	while (*pos < lex_tok_count) {
 
+		expr_list[i].value[0] = '\0';
+
 		switch (lex_tok[*pos]) {
 		case LEX_EXPR_START:
 			break;
 		case LEX_PAREN_OPEN:
 			expr_list[i].type = EXPR_PAREN_LEFT;
-			i++;;
+			i++;
 			break;
 		case LEX_PAREN_CLOSE:
 			if (expr_list[i - 1].type == EXPR_NODE_NAME) {

--- a/src/jsonpath/parser.c
+++ b/src/jsonpath/parser.c
@@ -234,7 +234,8 @@ bool build_parse_tree(
 					return false;
 				}
 			}
-			else if (i < lex_tok_count - 1 && lex_tok[i + 1] == LEX_FILTER_START) {
+			else if (i < lex_tok_count - 2 && lex_tok[i + 1] == LEX_FILTER_START) {
+
 				if (lex_tok[i + 2] == LEX_EXPR_END) {
 					strncpy(err->msg, "Filter must not be empty", sizeof(err->msg));
 					return false;

--- a/src/jsonpath/parser.c
+++ b/src/jsonpath/parser.c
@@ -218,7 +218,7 @@ bool build_parse_tree(
 
 			int_ptr = &i;
 
-			if (lex_tok[i + 1] == LEX_EXPR_START) {
+			if (i < lex_tok_count - 1 && lex_tok[i + 1] == LEX_EXPR_START) {
 
 				expr_count = get_expression_node_count(&lex_tok[0], *int_ptr, lex_tok_count);
 
@@ -234,7 +234,7 @@ bool build_parse_tree(
 					return false;
 				}
 			}
-			else if (lex_tok[i + 1] == LEX_FILTER_START) {
+			else if (i < lex_tok_count - 1 && lex_tok[i + 1] == LEX_FILTER_START) {
 				if (lex_tok[i + 2] == LEX_EXPR_END) {
 					strncpy(err->msg, "Filter must not be empty", sizeof(err->msg));
 					return false;


### PR DESCRIPTION
Fixes all the valgrind errors reported by `TEST_PHP_ARGS="-q -m" make test`.

Tests fixed:
```
< Test typical use cases [tests/001.phpt]
< Test typical use cases [tests/003.phpt]
< Ensure no segfault if filtering on object instead of array [tests/005.phpt]
< Ensure no "Array to string conversion" notice when selecting non-scalar [tests/006.phpt]
< Test bracket notation [tests/comparison_bracket_notation/001.phpt]
< Test bracket notation on object without key [tests/comparison_bracket_notation/002.phpt]
< Test bracket notation with NFC path on NFD key [tests/comparison_bracket_notation/004.phpt]
< Test bracket notation with dot [tests/comparison_bracket_notation/005.phpt]
< Test bracket notation with double quotes [tests/comparison_bracket_notation/006.phpt]
< Test bracket notation with empty string [tests/comparison_bracket_notation/008.phpt]
< Test bracket notation with empty string doubled quoted [tests/comparison_bracket_notation/009.phpt]
< Test bracket notation with quoted array slice literal [tests/comparison_bracket_notation/019.phpt]
< Test bracket notation with quoted closing bracket literal [tests/comparison_bracket_notation/020.phpt]
< Test bracket notation with quoted current object literal [tests/comparison_bracket_notation/021.phpt]
< Test bracket notation with quoted dot literal [tests/comparison_bracket_notation/022.phpt]
< Test bracket notation with quoted dot wildcard [tests/comparison_bracket_notation/023.phpt]
< Test bracket notation with quoted double quote literal [tests/comparison_bracket_notation/024.phpt]
< Test bracket notation with quoted escaped backslash [tests/comparison_bracket_notation/025.phpt]
< Test bracket notation with quoted escaped single quote [tests/comparison_bracket_notation/026.phpt]
< Test bracket notation with quoted root literal [tests/comparison_bracket_notation/028.phpt]
< Test bracket notation with quoted union literal [tests/comparison_bracket_notation/031.phpt]
< Test bracket notation with quoted wildcard literal [tests/comparison_bracket_notation/032.phpt]
< Test bracket notation with quoted wildcard literal on object without key [tests/comparison_bracket_notation/033.phpt]
< Test bracket notation with spaces [tests/comparison_bracket_notation/034.phpt]
< Test bracket notation with string including dot wildcard [tests/comparison_bracket_notation/035.phpt]
< Test typical use cases [tests/issue_27/001.phpt]
< Ensure exception is thrown for missing closing bracket [tests/parse_errs/001.phpt]
```

Also refactored `findByValue` and `checkIfKeyExists` so that the method names, signatures and documentation reflect reality.