### PR TITLE
Add dot notation tests from JSONPath Comparison

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -51,4 +51,4 @@ jobs:
 
             -   name: Show errors
                 if: ${{ failure() }}
-                run: ./.build.scripts/show-errors.sh
+                run: ./.build-scripts/show-errors.sh

--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,4 @@ tests/*/*.php
 tests/*/*.exp
 tests/*/*.log
 tests/*/*.sh
+!tests/utils/*.php

--- a/tests/comparison_dot_notation/001.phpt
+++ b/tests/comparison_dot_notation/001.phpt
@@ -1,0 +1,28 @@
+--TEST--
+Test dot bracket notation
+--SKIPIF--
+<?php if (!extension_loaded("jsonpath")) print "skip"; ?>
+--FILE--
+<?php
+
+$data = [
+    "key" => "value",
+    "other" => [
+        "key" => [
+            "key" => 42,
+        ],
+    ],
+];
+
+$jsonPath = new JsonPath();
+$result = $jsonPath->find($data, "$.['key']");
+
+echo "Assertion 1\n";
+var_dump($result);
+?>
+--EXPECT--
+Assertion 1
+array(1) {
+  [0]=>
+  string(5) "value"
+}

--- a/tests/comparison_dot_notation/002.phpt
+++ b/tests/comparison_dot_notation/002.phpt
@@ -1,0 +1,28 @@
+--TEST--
+Test dot bracket notation with double quotes
+--SKIPIF--
+<?php if (!extension_loaded("jsonpath")) print "skip"; ?>
+--FILE--
+<?php
+
+$data = [
+    "key" => "value",
+    "other" => [
+        "key" => [
+            "key" => 42,
+        ],
+    ],
+];
+
+$jsonPath = new JsonPath();
+$result = $jsonPath->find($data, '$.["key"]');
+
+echo "Assertion 1\n";
+var_dump($result);
+?>
+--EXPECT--
+Assertion 1
+array(1) {
+  [0]=>
+  string(5) "value"
+}

--- a/tests/comparison_dot_notation/003.phpt
+++ b/tests/comparison_dot_notation/003.phpt
@@ -1,0 +1,28 @@
+--TEST--
+Test dot bracket notation without quotes
+--SKIPIF--
+<?php if (!extension_loaded("jsonpath")) print "skip"; ?>
+--FILE--
+<?php
+
+$data = [
+    "key" => "value",
+    "other" => [
+        "key" => [
+            "key" => 42,
+        ],
+    ],
+];
+
+$jsonPath = new JsonPath();
+$result = $jsonPath->find($data, "$.[key]");
+
+echo "Assertion 1\n";
+var_dump($result);
+?>
+--EXPECTF--
+Fatal error: Uncaught RuntimeException: Filter must not be empty in %s003.php:%d
+Stack trace:
+#0 %s003.php(%d): JsonPath->find(Array, '$.[key]')
+#1 {main}
+  thrown in %s003.php on line %d

--- a/tests/comparison_dot_notation/004.phpt
+++ b/tests/comparison_dot_notation/004.phpt
@@ -1,0 +1,23 @@
+--TEST--
+Test dot notation
+--SKIPIF--
+<?php if (!extension_loaded("jsonpath")) print "skip"; ?>
+--FILE--
+<?php
+
+$data = [
+    "key" => "value",
+];
+
+$jsonPath = new JsonPath();
+$result = $jsonPath->find($data, "$.key");
+
+echo "Assertion 1\n";
+var_dump($result);
+?>
+--EXPECT--
+Assertion 1
+array(1) {
+  [0]=>
+  string(5) "value"
+}

--- a/tests/comparison_dot_notation/005.phpt
+++ b/tests/comparison_dot_notation/005.phpt
@@ -1,0 +1,21 @@
+--TEST--
+Test dot notation on array
+--SKIPIF--
+<?php if (!extension_loaded("jsonpath")) print "skip"; ?>
+--FILE--
+<?php
+
+$data = [
+    0,
+    1,
+];
+
+$jsonPath = new JsonPath();
+$result = $jsonPath->find($data, "$.key");
+
+echo "Assertion 1\n";
+var_dump($result);
+?>
+--EXPECT--
+Assertion 1
+bool(false)

--- a/tests/comparison_dot_notation/006.phpt
+++ b/tests/comparison_dot_notation/006.phpt
@@ -1,0 +1,31 @@
+--TEST--
+Test dot notation on array value
+--SKIPIF--
+<?php if (!extension_loaded("jsonpath")) print "skip"; ?>
+--FILE--
+<?php
+
+$data = [
+    "key" => [
+        "first",
+        "second",
+    ],
+];
+
+$jsonPath = new JsonPath();
+$result = $jsonPath->find($data, "$.key");
+
+echo "Assertion 1\n";
+var_dump($result);
+?>
+--EXPECT--
+Assertion 1
+array(1) {
+  [0]=>
+  array(2) {
+    [0]=>
+    string(5) "first"
+    [1]=>
+    string(6) "second"
+  }
+}

--- a/tests/comparison_dot_notation/007.phpt
+++ b/tests/comparison_dot_notation/007.phpt
@@ -1,0 +1,22 @@
+--TEST--
+Test dot notation on array with containing object matching key
+--SKIPIF--
+<?php if (!extension_loaded("jsonpath")) print "skip"; ?>
+--FILE--
+<?php
+
+$data = [
+    [
+        "id" => 2,
+    ],
+];
+
+$jsonPath = new JsonPath();
+$result = $jsonPath->find($data, "$.id");
+
+echo "Assertion 1\n";
+var_dump($result);
+?>
+--EXPECT--
+Assertion 1
+bool(false)

--- a/tests/comparison_dot_notation/008.phpt
+++ b/tests/comparison_dot_notation/008.phpt
@@ -1,0 +1,24 @@
+--TEST--
+Test dot notation on empty object value
+--SKIPIF--
+<?php if (!extension_loaded("jsonpath")) print "skip"; ?>
+--FILE--
+<?php
+
+$data = [
+    "key" => [],
+];
+
+$jsonPath = new JsonPath();
+$result = $jsonPath->find($data, "$.key");
+
+echo "Assertion 1\n";
+var_dump($result);
+?>
+--EXPECT--
+Assertion 1
+array(1) {
+  [0]=>
+  array(0) {
+  }
+}

--- a/tests/comparison_dot_notation/009.phpt
+++ b/tests/comparison_dot_notation/009.phpt
@@ -1,0 +1,23 @@
+--TEST--
+Test dot notation on null value
+--SKIPIF--
+<?php if (!extension_loaded("jsonpath")) print "skip"; ?>
+--FILE--
+<?php
+
+$data = [
+    "key" => null,
+];
+
+$jsonPath = new JsonPath();
+$result = $jsonPath->find($data, "$.key");
+
+echo "Assertion 1\n";
+var_dump($result);
+?>
+--EXPECT--
+Assertion 1
+array(1) {
+  [0]=>
+  NULL
+}

--- a/tests/comparison_dot_notation/010.phpt
+++ b/tests/comparison_dot_notation/010.phpt
@@ -1,0 +1,20 @@
+--TEST--
+Test dot notation on object without key
+--SKIPIF--
+<?php if (!extension_loaded("jsonpath")) print "skip"; ?>
+--FILE--
+<?php
+
+$data = [
+    "key" => "value",
+];
+
+$jsonPath = new JsonPath();
+$result = $jsonPath->find($data, "$.missing");
+
+echo "Assertion 1\n";
+var_dump($result);
+?>
+--EXPECT--
+Assertion 1
+bool(false)

--- a/tests/comparison_dot_notation/011.phpt
+++ b/tests/comparison_dot_notation/011.phpt
@@ -1,0 +1,33 @@
+--TEST--
+Test dot notation after array slice
+--SKIPIF--
+<?php if (!extension_loaded("jsonpath")) print "skip"; ?>
+--FILE--
+<?php
+
+$data = [
+    [
+        "key" => "ey",
+    ],
+    [
+        "key" => "bee",
+    ],
+    [
+        "key" => "see",
+    ],
+];
+
+$jsonPath = new JsonPath();
+$result = $jsonPath->find($data, "$[0:2].key");
+
+echo "Assertion 1\n";
+var_dump($result);
+?>
+--EXPECT--
+Assertion 1
+array(2) {
+  [0]=>
+  string(2) "ey"
+  [1]=>
+  string(3) "bee"
+}

--- a/tests/comparison_dot_notation/012.phpt
+++ b/tests/comparison_dot_notation/012.phpt
@@ -1,0 +1,62 @@
+--TEST--
+Test dot notation after bracket notation after recursive descent
+--SKIPIF--
+<?php if (!extension_loaded("jsonpath")) print "skip"; ?>
+--FILE--
+<?php
+
+$data = [
+    "k" => [
+        [
+            "key" => "some value",
+        ],
+        [
+            "key" => 42,
+        ],
+    ],
+    "kk" => [
+        [
+            [
+                "key" => 100,
+            ],
+            [
+                "key" => 200,
+            ],
+            [
+                "key" => 300,
+            ],
+            [
+                "key" => 400,
+            ],
+            [
+                "key" => 500,
+            ],
+            [
+                "key" => 600,
+            ],
+        ],
+    ],
+    "key" => [
+        0,
+        1,
+    ],
+];
+
+$jsonPath = new JsonPath();
+$result = $jsonPath->find($data, "$..[1].key");
+
+echo "Assertion 1\n";
+var_dump($result);
+?>
+--EXPECT--
+Assertion 1
+array(3) {
+  [0]=>
+  int(200)
+  [1]=>
+  int(42)
+  [2]=>
+  int(500)
+}
+--XFAIL--
+Requires more work on the recursive descent implementation

--- a/tests/comparison_dot_notation/013.phpt
+++ b/tests/comparison_dot_notation/013.phpt
@@ -1,0 +1,32 @@
+--TEST--
+Test dot notation after bracket notation with wildcard
+--SKIPIF--
+<?php if (!extension_loaded("jsonpath")) print "skip"; ?>
+--FILE--
+<?php
+
+$data = [
+    [
+        "a" => 1,
+    ],
+    [
+        "a" => 1,
+    ],
+];
+
+$jsonPath = new JsonPath();
+$result = $jsonPath->find($data, "$[*].a");
+
+echo "Assertion 1\n";
+var_dump($result);
+?>
+--EXPECT--
+Assertion 1
+array(2) {
+  [0]=>
+  int(1)
+  [1]=>
+  int(1)
+}
+--XFAIL--
+Requires more work on the wildcard implementation

--- a/tests/comparison_dot_notation/014.phpt
+++ b/tests/comparison_dot_notation/014.phpt
@@ -1,0 +1,27 @@
+--TEST--
+Test dot notation after bracket notation with wildcard on one matching
+--SKIPIF--
+<?php if (!extension_loaded("jsonpath")) print "skip"; ?>
+--FILE--
+<?php
+
+$data = [
+    [
+        "a" => 1,
+    ],
+];
+
+$jsonPath = new JsonPath();
+$result = $jsonPath->find($data, "$[*].a");
+
+echo "Assertion 1\n";
+var_dump($result);
+?>
+--EXPECT--
+Assertion 1
+array(1) {
+  [0]=>
+  int(1)
+}
+--XFAIL--
+Requires more work on the wildcard implementation

--- a/tests/comparison_dot_notation/015.phpt
+++ b/tests/comparison_dot_notation/015.phpt
@@ -1,0 +1,30 @@
+--TEST--
+Test dot notation after bracket notation with wildcard on some matching
+--SKIPIF--
+<?php if (!extension_loaded("jsonpath")) print "skip"; ?>
+--FILE--
+<?php
+
+$data = [
+    [
+        "a" => 1,
+    ],
+    [
+        "b" => 1,
+    ],
+];
+
+$jsonPath = new JsonPath();
+$result = $jsonPath->find($data, "$[*].a");
+
+echo "Assertion 1\n";
+var_dump($result);
+?>
+--EXPECT--
+Assertion 1
+array(1) {
+  [0]=>
+  int(1)
+}
+--XFAIL--
+Requires more work on the wildcard implementation

--- a/tests/comparison_dot_notation/016.phpt
+++ b/tests/comparison_dot_notation/016.phpt
@@ -1,0 +1,32 @@
+--TEST--
+Test dot notation after filter expression
+--SKIPIF--
+<?php if (!extension_loaded("jsonpath")) print "skip"; ?>
+--FILE--
+<?php
+
+$data = [
+    [
+        "id" => 42,
+        "name" => "forty-two",
+    ],
+    [
+        "id" => 1,
+        "name" => "one",
+    ],
+];
+
+$jsonPath = new JsonPath();
+$result = $jsonPath->find($data, "$[?(@.id==42)].name");
+
+echo "Assertion 1\n";
+var_dump($result);
+?>
+--EXPECT--
+Assertion 1
+array(1) {
+  [0]=>
+  string(9) "forty-two"
+}
+--XFAIL--
+Requires more work on the filter implementation

--- a/tests/comparison_dot_notation/017.phpt
+++ b/tests/comparison_dot_notation/017.phpt
@@ -1,0 +1,49 @@
+--TEST--
+Test dot notation after recursive descent
+--SKIPIF--
+<?php if (!extension_loaded("jsonpath")) print "skip"; ?>
+--FILE--
+<?php
+require_once __DIR__ . '/../utils/sort_recursively.php';
+
+$data = [
+    "object" => [
+        "key" => "value",
+        "array" => [
+            [
+                "key" => "something",
+            ],
+            [
+                "key" => [
+                    "key" => "russian dolls",
+                ],
+            ],
+        ],
+    ],
+    "key" => "top",
+];
+
+$jsonPath = new JsonPath();
+$result = $jsonPath->find($data, "$..key");
+sortRecursively($result);
+
+echo "Assertion 1\n";
+var_dump($result);
+?>
+--EXPECT--
+Assertion 1
+array(5) {
+  [0]=>
+  string(13) "russian dolls"
+  [1]=>
+  string(9) "something"
+  [2]=>
+  string(3) "top"
+  [3]=>
+  string(5) "value"
+  [4]=>
+  array(1) {
+    ["key"]=>
+    string(13) "russian dolls"
+  }
+}

--- a/tests/comparison_dot_notation/017.phpt
+++ b/tests/comparison_dot_notation/017.phpt
@@ -34,16 +34,16 @@ var_dump($result);
 Assertion 1
 array(5) {
   [0]=>
-  string(13) "russian dolls"
-  [1]=>
-  string(9) "something"
-  [2]=>
-  string(3) "top"
-  [3]=>
-  string(5) "value"
-  [4]=>
   array(1) {
     ["key"]=>
     string(13) "russian dolls"
   }
+  [1]=>
+  string(13) "russian dolls"
+  [2]=>
+  string(9) "something"
+  [3]=>
+  string(3) "top"
+  [4]=>
+  string(5) "value"
 }

--- a/tests/comparison_dot_notation/018.phpt
+++ b/tests/comparison_dot_notation/018.phpt
@@ -1,0 +1,66 @@
+--TEST--
+Test dot notation after recursive descent after dot notation
+--SKIPIF--
+<?php if (!extension_loaded("jsonpath")) print "skip"; ?>
+--FILE--
+<?php
+require_once __DIR__ . '/../utils/sort_recursively.php';
+
+$data = [
+    "store" => [
+        "book" => [
+            [
+                "category" => "reference",
+                "author" => "Nigel Rees",
+                "title" => "Sayings of the Century",
+                "price" => 8.95,
+            ],
+            [
+                "category" => "fiction",
+                "author" => "Evelyn Waugh",
+                "title" => "Sword of Honour",
+                "price" => 12.99,
+            ],
+            [
+                "category" => "fiction",
+                "author" => "Herman Melville",
+                "title" => "Moby Dick",
+                "isbn" => "0-553-21311-3",
+                "price" => 8.99,
+            ],
+            [
+                "category" => "fiction",
+                "author" => "J. R. R. Tolkien",
+                "title" => "The Lord of the Rings",
+                "isbn" => "0-395-19395-8",
+                "price" => 22.99,
+            ],
+        ],
+        "bicycle" => [
+            "color" => "red",
+            "price" => 19.95,
+        ],
+    ],
+];
+
+$jsonPath = new JsonPath();
+$result = $jsonPath->find($data, "$.store..price");
+sortRecursively($result);
+
+echo "Assertion 1\n";
+var_dump($result);
+?>
+--EXPECT--
+Assertion 1
+array(5) {
+  [0]=>
+  float(8.95)
+  [1]=>
+  float(8.99)
+  [2]=>
+  float(12.99)
+  [3]=>
+  float(19.95)
+  [4]=>
+  float(22.99)
+}

--- a/tests/comparison_dot_notation/019.phpt
+++ b/tests/comparison_dot_notation/019.phpt
@@ -1,0 +1,33 @@
+--TEST--
+Test dot notation after union
+--SKIPIF--
+<?php if (!extension_loaded("jsonpath")) print "skip"; ?>
+--FILE--
+<?php
+
+$data = [
+    [
+        "key" => "ey",
+    ],
+    [
+        "key" => "bee",
+    ],
+    [
+        "key" => "see",
+    ],
+];
+
+$jsonPath = new JsonPath();
+$result = $jsonPath->find($data, "$[0,2].key");
+
+echo "Assertion 1\n";
+var_dump($result);
+?>
+--EXPECT--
+Assertion 1
+array(2) {
+  [0]=>
+  string(2) "ey"
+  [1]=>
+  string(3) "see"
+}

--- a/tests/comparison_dot_notation/020.phpt
+++ b/tests/comparison_dot_notation/020.phpt
@@ -1,0 +1,36 @@
+--TEST--
+Test dot notation after union with keys
+--SKIPIF--
+<?php if (!extension_loaded("jsonpath")) print "skip"; ?>
+--FILE--
+<?php
+
+$data = [
+    "one" => [
+        "key" => "value",
+    ],
+    "two" => [
+        "k" => "v",
+    ],
+    "three" => [
+        "some" => "more",
+        "key" => "other value",
+    ],
+];
+
+$jsonPath = new JsonPath();
+$result = $jsonPath->find($data, "$['one','three'].key");
+
+echo "Assertion 1\n";
+var_dump($result);
+?>
+--EXPECT--
+Assertion 1
+array(2) {
+  [0]=>
+  string(5) "value"
+  [1]=>
+  string(11) "other value"
+}
+--XFAIL--
+Requires support for union with string literal keys

--- a/tests/comparison_dot_notation/021.phpt
+++ b/tests/comparison_dot_notation/021.phpt
@@ -1,0 +1,23 @@
+--TEST--
+Test dot notation with dash
+--SKIPIF--
+<?php if (!extension_loaded("jsonpath")) print "skip"; ?>
+--FILE--
+<?php
+
+$data = [
+    "key-dash" => "value",
+];
+
+$jsonPath = new JsonPath();
+$result = $jsonPath->find($data, "$.key-dash");
+
+echo "Assertion 1\n";
+var_dump($result);
+?>
+--EXPECT--
+Assertion 1
+array(1) {
+  [0]=>
+  string(5) "value"
+}

--- a/tests/comparison_dot_notation/022.phpt
+++ b/tests/comparison_dot_notation/022.phpt
@@ -1,0 +1,22 @@
+--TEST--
+Test dot notation with double quotes
+--SKIPIF--
+<?php if (!extension_loaded("jsonpath")) print "skip"; ?>
+--FILE--
+<?php
+
+$data = [
+    "key" => "value",
+    "\"key\"" => 42,
+];
+
+$jsonPath = new JsonPath();
+$result = $jsonPath->find($data, '$."key"');
+
+echo "Assertion 1\n";
+var_dump($result);
+?>
+--EXPECT--
+PHP Fatal Error
+--XFAIL--
+Now returns false, would be better to error out due to invalid syntax

--- a/tests/comparison_dot_notation/023.phpt
+++ b/tests/comparison_dot_notation/023.phpt
@@ -1,0 +1,40 @@
+--TEST--
+Test dot notation with double quotes after recursive descent
+--SKIPIF--
+<?php if (!extension_loaded("jsonpath")) print "skip"; ?>
+--FILE--
+<?php
+
+$data = [
+    "object" => [
+        "key" => "value",
+        "\"key\"" => 42,
+        "array" => [
+            [
+                "key" => "something",
+                "\"key\"" => 0,
+            ],
+            [
+                "key" => [
+                    "key" => "russian dolls",
+                ],
+                "\"key\"" => [
+                    "\"key\"" => 99,
+                ],
+            ],
+        ],
+    ],
+    "key" => "top",
+    "\"key\"" => 42,
+];
+
+$jsonPath = new JsonPath();
+$result = $jsonPath->find($data, '$.."key"');
+
+echo "Assertion 1\n";
+var_dump($result);
+?>
+--EXPECT--
+PHP Fatal Error
+--XFAIL--
+Now returns a bunch of values, would be better to error out due to invalid syntax

--- a/tests/comparison_dot_notation/024.phpt
+++ b/tests/comparison_dot_notation/024.phpt
@@ -1,0 +1,23 @@
+--TEST--
+Test dot notation with empty path
+--SKIPIF--
+<?php if (!extension_loaded("jsonpath")) print "skip"; ?>
+--FILE--
+<?php
+
+$data = [
+    "key" => 42,
+    "" => 9001,
+    "''" => "nice",
+];
+
+$jsonPath = new JsonPath();
+$result = $jsonPath->find($data, "$.");
+
+echo "Assertion 1\n";
+var_dump($result);
+?>
+--EXPECT--
+PHP Fatal Error
+--XFAIL--
+Now returns 9001, consensus is to not support empty path

--- a/tests/comparison_dot_notation/025.phpt
+++ b/tests/comparison_dot_notation/025.phpt
@@ -1,0 +1,23 @@
+--TEST--
+Test dot notation with key named in
+--SKIPIF--
+<?php if (!extension_loaded("jsonpath")) print "skip"; ?>
+--FILE--
+<?php
+
+$data = [
+    "in" => "value",
+];
+
+$jsonPath = new JsonPath();
+$result = $jsonPath->find($data, "$.in");
+
+echo "Assertion 1\n";
+var_dump($result);
+?>
+--EXPECT--
+Assertion 1
+array(1) {
+  [0]=>
+  string(5) "value"
+}

--- a/tests/comparison_dot_notation/026.phpt
+++ b/tests/comparison_dot_notation/026.phpt
@@ -1,0 +1,23 @@
+--TEST--
+Test dot notation with key named length
+--SKIPIF--
+<?php if (!extension_loaded("jsonpath")) print "skip"; ?>
+--FILE--
+<?php
+
+$data = [
+    "length" => "value",
+];
+
+$jsonPath = new JsonPath();
+$result = $jsonPath->find($data, "$.length");
+
+echo "Assertion 1\n";
+var_dump($result);
+?>
+--EXPECT--
+Assertion 1
+array(1) {
+  [0]=>
+  string(5) "value"
+}

--- a/tests/comparison_dot_notation/027.phpt
+++ b/tests/comparison_dot_notation/027.phpt
@@ -1,0 +1,22 @@
+--TEST--
+Test dot notation with key named length on array
+--SKIPIF--
+<?php if (!extension_loaded("jsonpath")) print "skip"; ?>
+--FILE--
+<?php
+
+$data = [
+    4,
+    5,
+    6,
+];
+
+$jsonPath = new JsonPath();
+$result = $jsonPath->find($data, "$.length");
+
+echo "Assertion 1\n";
+var_dump($result);
+?>
+--EXPECT--
+Assertion 1
+bool(false)

--- a/tests/comparison_dot_notation/028.phpt
+++ b/tests/comparison_dot_notation/028.phpt
@@ -1,0 +1,23 @@
+--TEST--
+Test dot notation with key named null
+--SKIPIF--
+<?php if (!extension_loaded("jsonpath")) print "skip"; ?>
+--FILE--
+<?php
+
+$data = [
+    "null" => "value",
+];
+
+$jsonPath = new JsonPath();
+$result = $jsonPath->find($data, "$.null");
+
+echo "Assertion 1\n";
+var_dump($result);
+?>
+--EXPECT--
+Assertion 1
+array(1) {
+  [0]=>
+  string(5) "value"
+}

--- a/tests/comparison_dot_notation/029.phpt
+++ b/tests/comparison_dot_notation/029.phpt
@@ -1,0 +1,23 @@
+--TEST--
+Test dot notation with key named true
+--SKIPIF--
+<?php if (!extension_loaded("jsonpath")) print "skip"; ?>
+--FILE--
+<?php
+
+$data = [
+    "true" => "value",
+];
+
+$jsonPath = new JsonPath();
+$result = $jsonPath->find($data, "$.true");
+
+echo "Assertion 1\n";
+var_dump($result);
+?>
+--EXPECT--
+Assertion 1
+array(1) {
+  [0]=>
+  string(5) "value"
+}

--- a/tests/comparison_dot_notation/030.phpt
+++ b/tests/comparison_dot_notation/030.phpt
@@ -1,0 +1,25 @@
+--TEST--
+Test dot notation with key root literal
+--SKIPIF--
+<?php if (!extension_loaded("jsonpath")) print "skip"; ?>
+--FILE--
+<?php
+
+$data = [
+    "$" => "value",
+];
+
+$jsonPath = new JsonPath();
+$result = $jsonPath->find($data, "$.$");
+
+echo "Assertion 1\n";
+var_dump($result);
+?>
+--EXPECT--
+Assertion 1
+array(1) {
+  [0]=>
+  string(5) "value"
+}
+--XFAIL--
+Requires support for a wider range of characters in node names

--- a/tests/comparison_dot_notation/031.phpt
+++ b/tests/comparison_dot_notation/031.phpt
@@ -1,0 +1,23 @@
+--TEST--
+Test dot notation with non ASCII key
+--SKIPIF--
+<?php if (!extension_loaded("jsonpath")) print "skip"; ?>
+--FILE--
+<?php
+
+$data = [
+    "屬性" => "value",
+];
+
+$jsonPath = new JsonPath();
+$result = $jsonPath->find($data, "$.屬性");
+
+echo "Assertion 1\n";
+var_dump($result);
+?>
+--EXPECT--
+Assertion 1
+array(1) {
+  [0]=>
+  string(5) "value"
+}

--- a/tests/comparison_dot_notation/032.phpt
+++ b/tests/comparison_dot_notation/032.phpt
@@ -1,0 +1,24 @@
+--TEST--
+Test dot notation with number
+--SKIPIF--
+<?php if (!extension_loaded("jsonpath")) print "skip"; ?>
+--FILE--
+<?php
+
+$data = [
+    "first",
+    "second",
+    "third",
+    "forth",
+    "fifth",
+];
+
+$jsonPath = new JsonPath();
+$result = $jsonPath->find($data, "$.2");
+
+echo "Assertion 1\n";
+var_dump($result);
+?>
+--EXPECT--
+Assertion 1
+bool(false)

--- a/tests/comparison_dot_notation/033.phpt
+++ b/tests/comparison_dot_notation/033.phpt
@@ -1,0 +1,27 @@
+--TEST--
+Test dot notation with number on object
+--SKIPIF--
+<?php if (!extension_loaded("jsonpath")) print "skip"; ?>
+--FILE--
+<?php
+
+$data = [
+    "a" => "first",
+    "2" => "second",
+    "c" => "third",
+];
+
+$jsonPath = new JsonPath();
+$result = $jsonPath->find($data, "$.2");
+
+echo "Assertion 1\n";
+var_dump($result);
+?>
+--EXPECT--
+Assertion 1
+array(1) {
+  [0]=>
+  string(6) "second"
+}
+--XFAIL--
+Requires support for numeric node names

--- a/tests/comparison_dot_notation/034.phpt
+++ b/tests/comparison_dot_notation/034.phpt
@@ -1,0 +1,24 @@
+--TEST--
+Test dot notation with number -1
+--SKIPIF--
+<?php if (!extension_loaded("jsonpath")) print "skip"; ?>
+--FILE--
+<?php
+
+$data = [
+    "first",
+    "second",
+    "third",
+    "forth",
+    "fifth",
+];
+
+$jsonPath = new JsonPath();
+$result = $jsonPath->find($data, "$.-1");
+
+echo "Assertion 1\n";
+var_dump($result);
+?>
+--EXPECT--
+Assertion 1
+bool(false)

--- a/tests/comparison_dot_notation/035.phpt
+++ b/tests/comparison_dot_notation/035.phpt
@@ -1,0 +1,22 @@
+--TEST--
+Test dot notation with single quotes
+--SKIPIF--
+<?php if (!extension_loaded("jsonpath")) print "skip"; ?>
+--FILE--
+<?php
+
+$data = [
+    "key" => "value",
+    "'key'" => 42,
+];
+
+$jsonPath = new JsonPath();
+$result = $jsonPath->find($data, "$.'key'");
+
+echo "Assertion 1\n";
+var_dump($result);
+?>
+--EXPECT--
+PHP Fatal Error
+--XFAIL--
+Now returns false, would be better to error out due to invalid syntax

--- a/tests/comparison_dot_notation/036.phpt
+++ b/tests/comparison_dot_notation/036.phpt
@@ -1,0 +1,40 @@
+--TEST--
+Test dot notation with single quotes after recursive descent
+--SKIPIF--
+<?php if (!extension_loaded("jsonpath")) print "skip"; ?>
+--FILE--
+<?php
+
+$data = [
+    "object" => [
+        "key" => "value",
+        "'key'" => 42,
+        "array" => [
+            [
+                "key" => "something",
+                "'key'" => 0,
+            ],
+            [
+                "key" => [
+                    "key" => "russian dolls",
+                ],
+                "'key'" => [
+                    "'key'" => 99,
+                ],
+            ],
+        ],
+    ],
+    "key" => "top",
+    "'key'" => 42,
+];
+
+$jsonPath = new JsonPath();
+$result = $jsonPath->find($data, "$..'key'");
+
+echo "Assertion 1\n";
+var_dump($result);
+?>
+--EXPECT--
+PHP Fatal Error
+--XFAIL--
+Now returns a bunch of values, would be better to error out due to invalid syntax

--- a/tests/comparison_dot_notation/037.phpt
+++ b/tests/comparison_dot_notation/037.phpt
@@ -1,0 +1,25 @@
+--TEST--
+Test dot notation with single quotes and dot
+--SKIPIF--
+<?php if (!extension_loaded("jsonpath")) print "skip"; ?>
+--FILE--
+<?php
+
+$data = [
+    "some.key" => 42,
+    "some" => [
+        "key" => "value",
+    ],
+    "'some.key'" => 43,
+];
+
+$jsonPath = new JsonPath();
+$result = $jsonPath->find($data, "$.'some.key'");
+
+echo "Assertion 1\n";
+var_dump($result);
+?>
+--EXPECT--
+PHP Fatal Error
+--XFAIL--
+Now returns false, would be better to error out due to invalid syntax

--- a/tests/comparison_dot_notation/038.phpt
+++ b/tests/comparison_dot_notation/038.phpt
@@ -1,0 +1,24 @@
+--TEST--
+Test dot notation with space padded key
+--SKIPIF--
+<?php if (!extension_loaded("jsonpath")) print "skip"; ?>
+--FILE--
+<?php
+
+$data = [
+    " a" => 1,
+    "a" => 2,
+    " a " => 3,
+    "" => 4,
+];
+
+$jsonPath = new JsonPath();
+$result = $jsonPath->find($data, "$. a");
+
+echo "Assertion 1\n";
+var_dump($result);
+?>
+--EXPECT--
+PHP Fatal Error
+--XFAIL--
+Now returns 2, would be better to error out due to invalid syntax

--- a/tests/comparison_dot_notation/039.phpt
+++ b/tests/comparison_dot_notation/039.phpt
@@ -1,0 +1,45 @@
+--TEST--
+Test dot notation with wildcard on array
+--SKIPIF--
+<?php if (!extension_loaded("jsonpath")) print "skip"; ?>
+--FILE--
+<?php
+
+$data = [
+    "string",
+    42,
+    [
+        "key" => "value",
+    ],
+    [
+        0,
+        1,
+    ],
+];
+
+$jsonPath = new JsonPath();
+$result = $jsonPath->find($data, "$.*");
+
+echo "Assertion 1\n";
+var_dump($result);
+?>
+--EXPECT--
+Assertion 1
+array(4) {
+  [0]=>
+  string(6) "string"
+  [1]=>
+  int(42)
+  [2]=>
+  array(1) {
+    ["key"]=>
+    string(5) "value"
+  }
+  [3]=>
+  array(2) {
+    [0]=>
+    int(0)
+    [1]=>
+    int(1)
+  }
+}

--- a/tests/comparison_dot_notation/040.phpt
+++ b/tests/comparison_dot_notation/040.phpt
@@ -1,0 +1,18 @@
+--TEST--
+Test dot notation with wildcard on empty array
+--SKIPIF--
+<?php if (!extension_loaded("jsonpath")) print "skip"; ?>
+--FILE--
+<?php
+
+$data = [];
+
+$jsonPath = new JsonPath();
+$result = $jsonPath->find($data, "$.*");
+
+echo "Assertion 1\n";
+var_dump($result);
+?>
+--EXPECT--
+Assertion 1
+bool(false)

--- a/tests/comparison_dot_notation/041.phpt
+++ b/tests/comparison_dot_notation/041.phpt
@@ -1,0 +1,18 @@
+--TEST--
+Test dot notation with wildcard on empty object
+--SKIPIF--
+<?php if (!extension_loaded("jsonpath")) print "skip"; ?>
+--FILE--
+<?php
+
+$data = [];
+
+$jsonPath = new JsonPath();
+$result = $jsonPath->find($data, "$.*");
+
+echo "Assertion 1\n";
+var_dump($result);
+?>
+--EXPECT--
+Assertion 1
+bool(false)

--- a/tests/comparison_dot_notation/042.phpt
+++ b/tests/comparison_dot_notation/042.phpt
@@ -29,19 +29,19 @@ var_dump($result);
 Assertion 1
 array(4) {
   [0]=>
-  int(42)
-  [1]=>
-  string(6) "string"
-  [2]=>
   array(1) {
     ["key"]=>
     string(5) "value"
   }
-  [3]=>
+  [1]=>
   array(2) {
     [0]=>
     int(0)
     [1]=>
     int(1)
   }
+  [2]=>
+  int(42)
+  [3]=>
+  string(6) "string"
 }

--- a/tests/comparison_dot_notation/042.phpt
+++ b/tests/comparison_dot_notation/042.phpt
@@ -1,0 +1,47 @@
+--TEST--
+Test dot notation with wildcard on object
+--SKIPIF--
+<?php if (!extension_loaded("jsonpath")) print "skip"; ?>
+--FILE--
+<?php
+require_once __DIR__ . '/../utils/sort_recursively.php';
+
+$data = [
+    "some" => "string",
+    "int" => 42,
+    "object" => [
+        "key" => "value",
+    ],
+    "array" => [
+        0,
+        1,
+    ],
+];
+
+$jsonPath = new JsonPath();
+$result = $jsonPath->find($data, "$.*");
+sortRecursively($result);
+
+echo "Assertion 1\n";
+var_dump($result);
+?>
+--EXPECT--
+Assertion 1
+array(4) {
+  [0]=>
+  int(42)
+  [1]=>
+  string(6) "string"
+  [2]=>
+  array(1) {
+    ["key"]=>
+    string(5) "value"
+  }
+  [3]=>
+  array(2) {
+    [0]=>
+    int(0)
+    [1]=>
+    int(1)
+  }
+}

--- a/tests/comparison_dot_notation/043.phpt
+++ b/tests/comparison_dot_notation/043.phpt
@@ -1,0 +1,27 @@
+--TEST--
+Test dot notation with wildcard after dot notation after dot notation with wildcard
+--SKIPIF--
+<?php if (!extension_loaded("jsonpath")) print "skip"; ?>
+--FILE--
+<?php
+
+$data = [
+    [
+        "bar" => [
+            42,
+        ],
+    ]
+];
+
+$jsonPath = new JsonPath();
+$result = $jsonPath->find($data, "$.*.bar.*");
+
+echo "Assertion 1\n";
+var_dump($result);
+?>
+--EXPECT--
+Assertion 1
+array(1) {
+  [0]=>
+  int(42)
+}

--- a/tests/comparison_dot_notation/044.phpt
+++ b/tests/comparison_dot_notation/044.phpt
@@ -1,0 +1,42 @@
+--TEST--
+Test dot notation with wildcard after dot notation with wildcard on nested arrays
+--SKIPIF--
+<?php if (!extension_loaded("jsonpath")) print "skip"; ?>
+--FILE--
+<?php
+
+$data = [
+    [
+        1,
+        2,
+        3,
+    ],
+    [
+        4,
+        5,
+        6,
+    ]
+];
+
+$jsonPath = new JsonPath();
+$result = $jsonPath->find($data, "$.*.*");
+
+echo "Assertion 1\n";
+var_dump($result);
+?>
+--EXPECT--
+Assertion 1
+array(6) {
+  [0]=>
+  int(1)
+  [1]=>
+  int(2)
+  [2]=>
+  int(3)
+  [3]=>
+  int(4)
+  [4]=>
+  int(5)
+  [5]=>
+  int(6)
+}

--- a/tests/comparison_dot_notation/045.phpt
+++ b/tests/comparison_dot_notation/045.phpt
@@ -1,0 +1,57 @@
+--TEST--
+Test dot notation with wildcard after recursive descent
+--SKIPIF--
+<?php if (!extension_loaded("jsonpath")) print "skip"; ?>
+--FILE--
+<?php
+
+$data = [
+    "key" => "value",
+    "another key" => [
+        "complex" => "string",
+        "primitives" => [
+            0,
+            1,
+        ],
+    ],
+];
+
+$jsonPath = new JsonPath();
+$result = $jsonPath->find($data, "$..*");
+
+echo "Assertion 1\n";
+var_dump($result);
+?>
+--EXPECT--
+Assertion 1
+array(6) {
+  [0]=>
+  string(6) "string"
+  [1]=>
+  string(5) "value"
+  [2]=>
+  int(0)
+  [3]=>
+  int(1)
+  [4]=>
+  array(2) {
+    [0]=>
+    int(0)
+    [1]=>
+    int(1)
+  }
+  [5]=>
+  array(2) {
+    ["complex"]=>
+    string(6) "string"
+    ["primitives"]=>
+    array(2) {
+      [0]=>
+      int(0)
+      [1]=>
+      int(1)
+    }
+  }
+}
+--XFAIL--
+Requires more work on the recursive descent implementation

--- a/tests/comparison_dot_notation/046.phpt
+++ b/tests/comparison_dot_notation/046.phpt
@@ -1,0 +1,31 @@
+--TEST--
+Test dot notation with wildcard after recursive descent on null value array
+--SKIPIF--
+<?php if (!extension_loaded("jsonpath")) print "skip"; ?>
+--FILE--
+<?php
+
+$data = [
+    40,
+    null,
+    42,
+];
+
+$jsonPath = new JsonPath();
+$result = $jsonPath->find($data, "$..*");
+
+echo "Assertion 1\n";
+var_dump($result);
+?>
+--EXPECT--
+Assertion 1
+array(3) {
+  [0]=>
+  int(40)
+  [1]=>
+  int(42)
+  [2]=>
+  NULL
+}
+--XFAIL--
+Requires more work on the recursive descent implementation

--- a/tests/comparison_dot_notation/047_php7.phpt
+++ b/tests/comparison_dot_notation/047_php7.phpt
@@ -1,0 +1,20 @@
+--TEST--
+Test dot notation with wildcard after recursive descent on scalar
+--SKIPIF--
+<?php if (!extension_loaded("jsonpath")) print "skip"; ?>
+<?php if (version_compare(PHP_VERSION, '8.0.0', '>=')) print "skip"; ?>
+--FILE--
+<?php
+
+$data = 42;
+
+$jsonPath = new JsonPath();
+$result = $jsonPath->find($data, "$..*");
+
+echo "Assertion 1\n";
+var_dump($result);
+?>
+--EXPECTF--
+Warning: JsonPath::find() expects parameter 1 to be array, int given in %s047_php7.php on line %d
+Assertion 1
+NULL

--- a/tests/comparison_dot_notation/047_php8.phpt
+++ b/tests/comparison_dot_notation/047_php8.phpt
@@ -1,0 +1,22 @@
+--TEST--
+Test dot notation with wildcard after recursive descent on scalar
+--SKIPIF--
+<?php if (!extension_loaded("jsonpath")) print "skip"; ?>
+<?php if (version_compare(PHP_VERSION, '8.0.0', '<')) print "skip"; ?>
+--FILE--
+<?php
+
+$data = 42;
+
+$jsonPath = new JsonPath();
+$result = $jsonPath->find($data, "$..*");
+
+echo "Assertion 1\n";
+var_dump($result);
+?>
+--EXPECTF--
+Fatal error: Uncaught TypeError: JsonPath::find(): Argument #1 ($data) must be of type array, int given in %s047_php8.php:%d
+Stack trace:
+#0 %s047_php8.php(%d): JsonPath->find(42, '$..*')
+#1 {main}
+  thrown in %s047_php8.php on line %d

--- a/tests/comparison_dot_notation/048.phpt
+++ b/tests/comparison_dot_notation/048.phpt
@@ -1,0 +1,22 @@
+--TEST--
+Test dot notation without dot
+--SKIPIF--
+<?php if (!extension_loaded("jsonpath")) print "skip"; ?>
+--FILE--
+<?php
+
+$data = [
+    "a" => 1,
+    "\$a" => 2,
+];
+
+$jsonPath = new JsonPath();
+$result = $jsonPath->find($data, "\$a");
+
+echo "Assertion 1\n";
+var_dump($result);
+?>
+--EXPECT--
+PHP Fatal Error
+--XFAIL--
+Now returns false, would be better to error out due to invalid syntax

--- a/tests/comparison_dot_notation/049.phpt
+++ b/tests/comparison_dot_notation/049.phpt
@@ -1,0 +1,21 @@
+--TEST--
+Test dot notation without root
+--SKIPIF--
+<?php if (!extension_loaded("jsonpath")) print "skip"; ?>
+--FILE--
+<?php
+
+$data = [
+    "key" => "value",
+];
+
+$jsonPath = new JsonPath();
+$result = $jsonPath->find($data, ".key");
+
+echo "Assertion 1\n";
+var_dump($result);
+?>
+--EXPECT--
+PHP Fatal Error
+--XFAIL--
+Now returns value, would be better to error out due to invalid syntax

--- a/tests/comparison_dot_notation/050.phpt
+++ b/tests/comparison_dot_notation/050.phpt
@@ -1,0 +1,21 @@
+--TEST--
+Test dot notation without root and dot
+--SKIPIF--
+<?php if (!extension_loaded("jsonpath")) print "skip"; ?>
+--FILE--
+<?php
+
+$data = [
+    "key" => "value",
+];
+
+$jsonPath = new JsonPath();
+$result = $jsonPath->find($data, "key");
+
+echo "Assertion 1\n";
+var_dump($result);
+?>
+--EXPECT--
+PHP Fatal Error
+--XFAIL--
+Now returns false, would be better to error out due to invalid syntax

--- a/tests/utils/sort_recursively.php
+++ b/tests/utils/sort_recursively.php
@@ -1,6 +1,23 @@
 <?php
 
 /**
+ * Comparison function for custom sort. Tries to achieve a canonical sort order across PHP versions
+ * by sorting primarily by type, secondarily by value.
+ * @param mixed $a
+ * @param mixed $b
+ *
+ * @return int
+ */
+function byTypeAndValue($a, $b): int
+{
+    if (gettype($a) !== gettype($b)) {
+        return gettype($a) <=> gettype($b);
+    } else {
+        return $a <=> $b;
+    }
+}
+
+/**
  * Sort an array by its values, recursively
  * @param array &$array
  */
@@ -8,11 +25,11 @@ function sortRecursively(array &$array): void
 {
     // Sequential array, re-index after sorting
     if (array_keys($array) === range(0, count($array) - 1)) {
-        sort($array);
+        usort($array, 'byTypeAndValue');
     }
     // Associative array, maintain keys
     else {
-        asort($array);
+        uasort($array, 'byTypeAndValue');
     }
     
     foreach ($array as &$value) {

--- a/tests/utils/sort_recursively.php
+++ b/tests/utils/sort_recursively.php
@@ -1,12 +1,16 @@
 <?php
 
-function sortRecursively(&$array): void
+/**
+ * Sort an array by its values, recursively
+ * @param array &$array
+ */
+function sortRecursively(array &$array): void
 {
     // Sequential array, re-index after sorting
     if (array_keys($array) === range(0, count($array) - 1)) {
         sort($array);
     }
-    // Associative, maintain keys
+    // Associative array, maintain keys
     else {
         asort($array);
     }

--- a/tests/utils/sort_recursively.php
+++ b/tests/utils/sort_recursively.php
@@ -1,0 +1,19 @@
+<?php
+
+function sortRecursively(&$array): void
+{
+    // Sequential array, re-index after sorting
+    if (array_keys($array) === range(0, count($array) - 1)) {
+        sort($array);
+    }
+    // Associative, maintain keys
+    else {
+        asort($array);
+    }
+    
+    foreach ($array as &$value) {
+        if (is_array($value)) {
+            sortRecursively($value);
+        }
+    }
+}


### PR DESCRIPTION
Adds the 50 dot notation tests from [JSONPath Comparison](https://cburgmer.github.io/json-path-comparison/), using the consensus result where there is one, and something that seems logical where there isn't consensus.

No changes to the implementation itself, but there are a bunch of tests that are currently expected to fail, needing changes to wildcard and recursive descent traversal in particular.