### PR TITLE
Fix bracket and dot notation JSONPath Comparison tests following switch to AST implementation

### DIFF
--- a/tests/comparison_bracket_notation/003.phpt
+++ b/tests/comparison_bracket_notation/003.phpt
@@ -4,6 +4,7 @@ Test bracket notation after recursive descent
 <?php if (!extension_loaded("jsonpath")) print "skip"; ?>
 --FILE--
 <?php
+require_once __DIR__ . '/../utils/sort_recursively.php';
 
 $data = [
     "first",
@@ -30,6 +31,7 @@ $data = [
 
 $jsonPath = new JsonPath();
 $result = $jsonPath->find($data, '$..[0]');
+sortRecursively($result);
 
 echo "Assertion 1\n";
 var_dump($result);
@@ -38,14 +40,6 @@ var_dump($result);
 Assertion 1
 array(5) {
   [0]=>
-  string(7) "deepest"
-  [1]=>
-  string(12) "first nested"
-  [2]=>
-  string(5) "first"
-  [3]=>
-  string(4) "more"
-  [4]=>
   array(1) {
     ["nested"]=>
     array(2) {
@@ -55,6 +49,12 @@ array(5) {
       string(6) "second"
     }
   }
+  [1]=>
+  string(7) "deepest"
+  [2]=>
+  string(5) "first"
+  [3]=>
+  string(12) "first nested"
+  [4]=>
+  string(4) "more"
 }
---XFAIL--
-Requires more work on the recursive descent implementation

--- a/tests/comparison_bracket_notation/015.phpt
+++ b/tests/comparison_bracket_notation/015.phpt
@@ -23,9 +23,7 @@ var_dump($result);
 ?>
 --EXPECT--
 Assertion 1
-array[1]{
+array(1) {
   [0]=>
   int(3)
 }
---XFAIL--
-Requires filter handling in wildcard iteration

--- a/tests/comparison_bracket_notation/038.phpt
+++ b/tests/comparison_bracket_notation/038.phpt
@@ -43,5 +43,3 @@ array(4) {
     int(1)
   }
 }
---XFAIL--
-Requires more work on the wildcard iteration

--- a/tests/comparison_bracket_notation/041.phpt
+++ b/tests/comparison_bracket_notation/041.phpt
@@ -27,5 +27,3 @@ array(3) {
   [2]=>
   int(42)
 }
---XFAIL--
-Requires more work on the wildcard iteration

--- a/tests/comparison_bracket_notation/042.phpt
+++ b/tests/comparison_bracket_notation/042.phpt
@@ -26,16 +26,16 @@ var_dump($result);
 --EXPECT--
 Assertion 1
 array(4) {
-  ["some"]=>
+  [0]=>
   string(6) "string"
-  ["int"]=>
+  [1]=>
   int(42)
-  ["object"]=>
+  [2]=>
   array(1) {
     ["key"]=>
     string(5) "value"
   }
-  ["array"]=>
+  [3]=>
   array(2) {
     [0]=>
     int(0)
@@ -43,5 +43,3 @@ array(4) {
     int(1)
   }
 }
---XFAIL--
-Requires more work on the wildcard iteration

--- a/tests/comparison_bracket_notation/044.phpt
+++ b/tests/comparison_bracket_notation/044.phpt
@@ -25,5 +25,3 @@ array(1) {
   [0]=>
   int(42)
 }
---XFAIL--
-Requires more work on the wildcard iteration

--- a/tests/comparison_dot_notation/012.phpt
+++ b/tests/comparison_dot_notation/012.phpt
@@ -4,6 +4,7 @@ Test dot notation after bracket notation after recursive descent
 <?php if (!extension_loaded("jsonpath")) print "skip"; ?>
 --FILE--
 <?php
+require_once __DIR__ . '/../utils/sort_recursively.php';
 
 $data = [
     "k" => [
@@ -26,13 +27,15 @@ $data = [
                 "key" => 300,
             ],
             [
-                "key" => 400,
-            ],
-            [
-                "key" => 500,
-            ],
-            [
-                "key" => 600,
+                [
+                    "key" => 400,
+                ],
+                [
+                    "key" => 500,
+                ],
+                [
+                    "key" => 600,
+                ],
             ],
         ],
     ],
@@ -44,6 +47,7 @@ $data = [
 
 $jsonPath = new JsonPath();
 $result = $jsonPath->find($data, "$..[1].key");
+sortRecursively($result);
 
 echo "Assertion 1\n";
 var_dump($result);
@@ -52,11 +56,9 @@ var_dump($result);
 Assertion 1
 array(3) {
   [0]=>
-  int(200)
-  [1]=>
   int(42)
+  [1]=>
+  int(200)
   [2]=>
   int(500)
 }
---XFAIL--
-Requires more work on the recursive descent implementation

--- a/tests/comparison_dot_notation/013.phpt
+++ b/tests/comparison_dot_notation/013.phpt
@@ -28,5 +28,3 @@ array(2) {
   [1]=>
   int(1)
 }
---XFAIL--
-Requires more work on the wildcard implementation

--- a/tests/comparison_dot_notation/014.phpt
+++ b/tests/comparison_dot_notation/014.phpt
@@ -23,5 +23,3 @@ array(1) {
   [0]=>
   int(1)
 }
---XFAIL--
-Requires more work on the wildcard implementation

--- a/tests/comparison_dot_notation/015.phpt
+++ b/tests/comparison_dot_notation/015.phpt
@@ -26,5 +26,3 @@ array(1) {
   [0]=>
   int(1)
 }
---XFAIL--
-Requires more work on the wildcard implementation

--- a/tests/comparison_dot_notation/016.phpt
+++ b/tests/comparison_dot_notation/016.phpt
@@ -28,5 +28,3 @@ array(1) {
   [0]=>
   string(9) "forty-two"
 }
---XFAIL--
-Requires more work on the filter implementation

--- a/tests/comparison_dot_notation/023.phpt
+++ b/tests/comparison_dot_notation/023.phpt
@@ -37,4 +37,4 @@ var_dump($result);
 --EXPECT--
 PHP Fatal Error
 --XFAIL--
-Now returns a bunch of values, would be better to error out due to invalid syntax
+Now returns false, would be better to error out due to invalid syntax

--- a/tests/comparison_dot_notation/036.phpt
+++ b/tests/comparison_dot_notation/036.phpt
@@ -37,4 +37,4 @@ var_dump($result);
 --EXPECT--
 PHP Fatal Error
 --XFAIL--
-Now returns a bunch of values, would be better to error out due to invalid syntax
+Now returns false, would be better to error out due to invalid syntax

--- a/tests/comparison_dot_notation/045.phpt
+++ b/tests/comparison_dot_notation/045.phpt
@@ -4,6 +4,7 @@ Test dot notation with wildcard after recursive descent
 <?php if (!extension_loaded("jsonpath")) print "skip"; ?>
 --FILE--
 <?php
+require_once __DIR__ . '/../utils/sort_recursively.php';
 
 $data = [
     "key" => "value",
@@ -18,6 +19,7 @@ $data = [
 
 $jsonPath = new JsonPath();
 $result = $jsonPath->find($data, "$..*");
+sortRecursively($result);
 
 echo "Assertion 1\n";
 var_dump($result);
@@ -26,24 +28,14 @@ var_dump($result);
 Assertion 1
 array(6) {
   [0]=>
-  string(6) "string"
-  [1]=>
-  string(5) "value"
-  [2]=>
-  int(0)
-  [3]=>
-  int(1)
-  [4]=>
   array(2) {
     [0]=>
     int(0)
     [1]=>
     int(1)
   }
-  [5]=>
+  [1]=>
   array(2) {
-    ["complex"]=>
-    string(6) "string"
     ["primitives"]=>
     array(2) {
       [0]=>
@@ -51,7 +43,15 @@ array(6) {
       [1]=>
       int(1)
     }
+    ["complex"]=>
+    string(6) "string"
   }
+  [2]=>
+  int(0)
+  [3]=>
+  int(1)
+  [4]=>
+  string(6) "string"
+  [5]=>
+  string(5) "value"
 }
---XFAIL--
-Requires more work on the recursive descent implementation

--- a/tests/comparison_dot_notation/046.phpt
+++ b/tests/comparison_dot_notation/046.phpt
@@ -4,6 +4,7 @@ Test dot notation with wildcard after recursive descent on null value array
 <?php if (!extension_loaded("jsonpath")) print "skip"; ?>
 --FILE--
 <?php
+require_once __DIR__ . '/../utils/sort_recursively.php';
 
 $data = [
     40,
@@ -13,6 +14,7 @@ $data = [
 
 $jsonPath = new JsonPath();
 $result = $jsonPath->find($data, "$..*");
+sortRecursively($result);
 
 echo "Assertion 1\n";
 var_dump($result);
@@ -21,11 +23,9 @@ var_dump($result);
 Assertion 1
 array(3) {
   [0]=>
-  int(40)
-  [1]=>
-  int(42)
-  [2]=>
   NULL
+  [1]=>
+  int(40)
+  [2]=>
+  int(42)
 }
---XFAIL--
-Requires more work on the recursive descent implementation


### PR DESCRIPTION
https://github.com/supermetrics/php-ext-jsonpath/pull/25 fixed various things, especially related to recursive descent and wildcard iteration. Many more JSONPath Comparison tests now pass.