### PR TITLE
Add union tests from JSONPath Comparison tests

### DIFF
--- a/tests/comparison_union/001.phpt
+++ b/tests/comparison_union/001.phpt
@@ -1,0 +1,27 @@
+--TEST--
+Test union
+--SKIPIF--
+<?php if (!extension_loaded("jsonpath")) print "skip"; ?>
+--FILE--
+<?php
+
+$data = [
+    "first",
+    "second",
+    "third",
+];
+
+$jsonPath = new JsonPath();
+$result = $jsonPath->find($data, "$[0,1]");
+
+echo "Assertion 1\n";
+var_dump($result);
+?>
+--EXPECT--
+Assertion 1
+array(2) {
+  [0]=>
+  string(5) "first"
+  [1]=>
+  string(6) "second"
+}

--- a/tests/comparison_union/002.phpt
+++ b/tests/comparison_union/002.phpt
@@ -1,0 +1,25 @@
+--TEST--
+Test union with duplication from array
+--SKIPIF--
+<?php if (!extension_loaded("jsonpath")) print "skip"; ?>
+--FILE--
+<?php
+
+$data = [
+    "a",
+];
+
+$jsonPath = new JsonPath();
+$result = $jsonPath->find($data, "$[0,0]");
+
+echo "Assertion 1\n";
+var_dump($result);
+?>
+--EXPECT--
+Assertion 1
+array(2) {
+  [0]=>
+  string(1) "a"
+  [1]=>
+  string(1) "a"
+}

--- a/tests/comparison_union/003.phpt
+++ b/tests/comparison_union/003.phpt
@@ -1,0 +1,27 @@
+--TEST--
+Test union with duplication from object
+--SKIPIF--
+<?php if (!extension_loaded("jsonpath")) print "skip"; ?>
+--FILE--
+<?php
+
+$data = [
+    "a" => 1,
+];
+
+$jsonPath = new JsonPath();
+$result = $jsonPath->find($data, "$['a','a']");
+
+echo "Assertion 1\n";
+var_dump($result);
+?>
+--EXPECT--
+Assertion 1
+array(2) {
+  [0]=>
+  int(1)
+  [1]=>
+  int(1)
+}
+--XFAIL--
+Requires more work on union implementation

--- a/tests/comparison_union/004.phpt
+++ b/tests/comparison_union/004.phpt
@@ -1,0 +1,71 @@
+--TEST--
+Test union with filter
+--SKIPIF--
+<?php if (!extension_loaded("jsonpath")) print "skip"; ?>
+--FILE--
+<?php
+
+$data = [
+    [
+        "key" => 1,
+    ],
+    [
+        "key" => 8,
+    ],
+    [
+        "key" => 3,
+    ],
+    [
+        "key" => 10,
+    ],
+    [
+        "key" => 7,
+    ],
+    [
+        "key" => 2,
+    ],
+    [
+        "key" => 6,
+    ],
+    [
+        "key" => 4,
+    ],
+];
+
+$jsonPath = new JsonPath();
+$result = $jsonPath->find($data, "$[?(@.key<3),?(@.key>6)]");
+
+echo "Assertion 1\n";
+var_dump($result);
+?>
+--EXPECT--
+Assertion 1
+array(5) {
+  [0]=>
+  array(1) {
+    ["key"]=>
+    int(1)
+  }
+  [1]=>
+  array(1) {
+    ["key"]=>
+    int(2)
+  }
+  [2]=>
+  array(1) {
+    ["key"]=>
+    int(8)
+  }
+  [3]=>
+  array(1) {
+    ["key"]=>
+    int(10)
+  }
+  [4]=>
+  array(1) {
+    ["key"]=>
+    int(7)
+  }
+}
+--XFAIL--
+Requires more work on union implementation

--- a/tests/comparison_union/005.phpt
+++ b/tests/comparison_union/005.phpt
@@ -1,0 +1,28 @@
+--TEST--
+Test union with keys
+--SKIPIF--
+<?php if (!extension_loaded("jsonpath")) print "skip"; ?>
+--FILE--
+<?php
+
+$data = [
+    "key" => "value",
+    "another" => "entry",
+];
+
+$jsonPath = new JsonPath();
+$result = $jsonPath->find($data, "$['key','another']");
+
+echo "Assertion 1\n";
+var_dump($result);
+?>
+--EXPECT--
+Assertion 1
+array(2) {
+  [0]=>
+  string(5) "value"
+  [1]=>
+  string(5) "entry"
+}
+--XFAIL--
+Requires more work on union implementation

--- a/tests/comparison_union/006.phpt
+++ b/tests/comparison_union/006.phpt
@@ -1,0 +1,26 @@
+--TEST--
+Test union with keys on object without key
+--SKIPIF--
+<?php if (!extension_loaded("jsonpath")) print "skip"; ?>
+--FILE--
+<?php
+
+$data = [
+    "key" => "value",
+    "another" => "entry",
+];
+
+$jsonPath = new JsonPath();
+$result = $jsonPath->find($data, "$['missing','key']");
+
+echo "Assertion 1\n";
+var_dump($result);
+?>
+--EXPECT--
+Assertion 1
+array(1) {
+  [0]=>
+  string(5) "value"
+}
+--XFAIL--
+Requires more work on union implementation

--- a/tests/comparison_union/007.phpt
+++ b/tests/comparison_union/007.phpt
@@ -1,0 +1,40 @@
+--TEST--
+Test union with keys after array slice
+--SKIPIF--
+<?php if (!extension_loaded("jsonpath")) print "skip"; ?>
+--FILE--
+<?php
+
+$data = [
+    [
+        "c" => "cc1",
+        "d" => "dd1",
+        "e" => "ee1",
+    ],
+    [
+        "c" => "cc2",
+        "d" => "dd2",
+        "e" => "ee2",
+    ],
+];
+
+$jsonPath = new JsonPath();
+$result = $jsonPath->find($data, "$[:]['c','d']");
+
+echo "Assertion 1\n";
+var_dump($result);
+?>
+--EXPECT--
+Assertion 1
+array(4) {
+  [0]=>
+  string(3) "cc1"
+  [1]=>
+  string(3) "dd1"
+  [2]=>
+  string(3) "cc2"
+  [3]=>
+  string(3) "dd2"
+}
+--XFAIL--
+Requires more work on union implementation

--- a/tests/comparison_union/008.phpt
+++ b/tests/comparison_union/008.phpt
@@ -1,0 +1,36 @@
+--TEST--
+Test union with keys after bracket notation
+--SKIPIF--
+<?php if (!extension_loaded("jsonpath")) print "skip"; ?>
+--FILE--
+<?php
+
+$data = [
+    [
+        "c" => "cc1",
+        "d" => "dd1",
+        "e" => "ee1",
+    ],
+    [
+        "c" => "cc2",
+        "d" => "dd2",
+        "e" => "ee2",
+    ],
+];
+
+$jsonPath = new JsonPath();
+$result = $jsonPath->find($data, "$[0]['c','d']");
+
+echo "Assertion 1\n";
+var_dump($result);
+?>
+--EXPECT--
+Assertion 1
+array(2) {
+  [0]=>
+  string(3) "cc1"
+  [1]=>
+  string(3) "dd1"
+}
+--XFAIL--
+Requires more work on union implementation

--- a/tests/comparison_union/009.phpt
+++ b/tests/comparison_union/009.phpt
@@ -1,0 +1,40 @@
+--TEST--
+Test union with keys after dot notation with wildcard
+--SKIPIF--
+<?php if (!extension_loaded("jsonpath")) print "skip"; ?>
+--FILE--
+<?php
+
+$data = [
+    [
+        "c" => "cc1",
+        "d" => "dd1",
+        "e" => "ee1",
+    ],
+    [
+        "c" => "cc2",
+        "d" => "dd2",
+        "e" => "ee2",
+    ],
+];
+
+$jsonPath = new JsonPath();
+$result = $jsonPath->find($data, "$.*['c','d']");
+
+echo "Assertion 1\n";
+var_dump($result);
+?>
+--EXPECT--
+Assertion 1
+array(4) {
+  [0]=>
+  string(3) "cc1"
+  [1]=>
+  string(3) "dd1"
+  [2]=>
+  string(3) "cc2"
+  [3]=>
+  string(3) "dd2"
+}
+--XFAIL--
+Requires more work on union implementation

--- a/tests/comparison_union/010.phpt
+++ b/tests/comparison_union/010.phpt
@@ -1,0 +1,60 @@
+--TEST--
+Test union with keys after recursive descent
+--SKIPIF--
+<?php if (!extension_loaded("jsonpath")) print "skip"; ?>
+--FILE--
+<?php
+require_once __DIR__ . '/../utils/sort_recursively.php';
+
+$data = [
+    [
+        "c" => "cc1",
+        "d" => "dd1",
+        "e" => "ee1",
+    ],
+    [
+        "c" => "cc2",
+        "child" => [
+            "d" => "dd2",
+        ],
+    ],
+    [
+        "c" => "cc3",
+    ],
+    [
+        "d" => "dd4",
+    ],
+    [
+        "child" => [
+            "c" => "cc5",
+        ],
+    ],
+];
+
+$jsonPath = new JsonPath();
+$result = $jsonPath->find($data, "$..['c','d']");
+sortRecursively($result);
+
+echo "Assertion 1\n";
+var_dump($result);
+?>
+--EXPECT--
+Assertion 1
+array(7) {
+  [0]=>
+  string(3) "cc1"
+  [1]=>
+  string(3) "cc2"
+  [2]=>
+  string(3) "cc3"
+  [3]=>
+  string(3) "cc5"
+  [4]=>
+  string(3) "dd1"
+  [5]=>
+  string(3) "dd2"
+  [6]=>
+  string(3) "dd4"
+}
+--XFAIL--
+Requires more work on union implementation

--- a/tests/comparison_union/011.phpt
+++ b/tests/comparison_union/011.phpt
@@ -1,0 +1,29 @@
+--TEST--
+Test union with numbers in decreasing order
+--SKIPIF--
+<?php if (!extension_loaded("jsonpath")) print "skip"; ?>
+--FILE--
+<?php
+
+$data = [
+    1,
+    2,
+    3,
+    4,
+    5,
+];
+
+$jsonPath = new JsonPath();
+$result = $jsonPath->find($data, "$[4,1]");
+
+echo "Assertion 1\n";
+var_dump($result);
+?>
+--EXPECT--
+Assertion 1
+array(2) {
+  [0]=>
+  int(5)
+  [1]=>
+  int(2)
+}

--- a/tests/comparison_union/012.phpt
+++ b/tests/comparison_union/012.phpt
@@ -1,0 +1,30 @@
+--TEST--
+Test union with repeated matches after dot notation with wildcard
+--SKIPIF--
+<?php if (!extension_loaded("jsonpath")) print "skip"; ?>
+--FILE--
+<?php
+
+$data = [
+    "a" => [
+        "string",
+        null,
+        true,
+    ],
+    "b" => [
+        false,
+        "string",
+        5.4,
+    ],
+];
+
+$jsonPath = new JsonPath();
+$result = $jsonPath->find($data, "$.*[0,:5]");
+
+echo "Assertion 1\n";
+var_dump($result);
+?>
+--EXPECT--
+PHP Fatal Error
+--XFAIL--
+Now returns a bunch of values, would be better to error out due to invalid syntax

--- a/tests/comparison_union/013.phpt
+++ b/tests/comparison_union/013.phpt
@@ -1,0 +1,25 @@
+--TEST--
+Test union with slice and number
+--SKIPIF--
+<?php if (!extension_loaded("jsonpath")) print "skip"; ?>
+--FILE--
+<?php
+
+$data = [
+    1,
+    2,
+    3,
+    4,
+    5,
+];
+
+$jsonPath = new JsonPath();
+$result = $jsonPath->find($data, "$[1:3,4]");
+
+echo "Assertion 1\n";
+var_dump($result);
+?>
+--EXPECT--
+PHP Fatal Error
+--XFAIL--
+Now returns a bunch of values, would be better to error out due to invalid syntax

--- a/tests/comparison_union/014.phpt
+++ b/tests/comparison_union/014.phpt
@@ -1,0 +1,27 @@
+--TEST--
+Test union with spaces
+--SKIPIF--
+<?php if (!extension_loaded("jsonpath")) print "skip"; ?>
+--FILE--
+<?php
+
+$data = [
+    "first",
+    "second",
+    "third",
+];
+
+$jsonPath = new JsonPath();
+$result = $jsonPath->find($data, "$[ 0 , 1 ]");
+
+echo "Assertion 1\n";
+var_dump($result);
+?>
+--EXPECT--
+Assertion 1
+array(2) {
+  [0]=>
+  string(5) "first"
+  [1]=>
+  string(6) "second"
+}

--- a/tests/comparison_union/015.phpt
+++ b/tests/comparison_union/015.phpt
@@ -1,0 +1,27 @@
+--TEST--
+Test union with wildcard and number
+--SKIPIF--
+<?php if (!extension_loaded("jsonpath")) print "skip"; ?>
+--FILE--
+<?php
+
+$data = [
+    "first",
+    "second",
+    "third",
+    "forth",
+    "fifth",
+];
+
+$jsonPath = new JsonPath();
+$result = $jsonPath->find($data, "$[*,1]");
+
+echo "Assertion 1\n";
+var_dump($result);
+?>
+--EXPECTF--
+Fatal error: Uncaught RuntimeException: Missing filter end ] in %s015.php:%d
+Stack trace:
+#0 %s015.php(%d): JsonPath->find(Array, '$[*,1]')
+#1 {main}
+  thrown in %s015.php on line %d


### PR DESCRIPTION
Adds the 15 union tests from [JSONPath Comparison](https://cburgmer.github.io/json-path-comparison/), using the consensus result where there is one, and something that seems logical where there isn't consensus.

With this last set of JSONPath Comparison tests, the full test suite now contains 269 tests of which 80 are currently expected fails.