### PR TITLE
Support fully recursive expression values

### DIFF
--- a/jsonpath.c
+++ b/jsonpath.c
@@ -82,7 +82,7 @@ PHP_METHOD(JsonPath, find) {
 
   array_init(return_value);
 
-  eval_ast(search_target, head.next, return_value);
+  eval_ast(search_target, search_target, head.next, return_value);
 
   free_ast_nodes(head.next);
 

--- a/src/jsonpath/interpreter.c
+++ b/src/jsonpath/interpreter.c
@@ -272,10 +272,9 @@ bool compare_rgxp(zval* lh, zval* rh) {
 
 zval* operand_to_zval(struct ast_node* src, zval* tmp_dest, zval* arr) {
   if (src->type == AST_SELECTOR) {
-    zval* return_value;
-    array_init(return_value);
-    eval_ast(arr, src->data.d_operand.head, return_value);
-    return zend_hash_index_find(Z_ARRVAL_P(return_value), 0);
+    array_init(tmp_dest);
+    eval_ast(arr, src, tmp_dest);
+    return zend_hash_index_find(Z_ARRVAL_P(tmp_dest), 0);
   } else if (src->type == AST_LITERAL) {
     ZVAL_STRING(tmp_dest, src->data.d_literal.value);
     return tmp_dest;

--- a/src/jsonpath/interpreter.c
+++ b/src/jsonpath/interpreter.c
@@ -272,7 +272,10 @@ bool compare_rgxp(zval* lh, zval* rh) {
 
 zval* operand_to_zval(struct ast_node* src, zval* tmp_dest, zval* arr) {
   if (src->type == AST_SELECTOR) {
-    return exec_selector_iterative(arr, src);
+    zval* return_value;
+    array_init(return_value);
+    eval_ast(arr, src->data.d_operand.head, return_value);
+    return zend_hash_index_find(Z_ARRVAL_P(return_value), 0);
   } else if (src->type == AST_LITERAL) {
     ZVAL_STRING(tmp_dest, src->data.d_literal.value);
     return tmp_dest;

--- a/src/jsonpath/interpreter.h
+++ b/src/jsonpath/interpreter.h
@@ -4,6 +4,6 @@
 #include "parser.h"
 #include "php.h"
 
-void eval_ast(zval* arr, struct ast_node* tok, zval* return_value);
+void eval_ast(zval* arr_head, zval* arr_cur, struct ast_node* tok, zval* return_value);
 
 #endif /* INTERPRETER_H */

--- a/src/jsonpath/parser.c
+++ b/src/jsonpath/parser.c
@@ -488,7 +488,7 @@ bool evaluate_postfix_expression(zval* arr, struct ast_node* tok) {
 
         stack_pop(&s);
 
-        if (evaluate_subexpression(arr, tok->type, expr_lh->data.d_operand.head, expr_rh->data.d_operand.head)) {
+        if (evaluate_subexpression(arr, tok->type, expr_lh, expr_rh)) {
           stack_push(&s, &op_true);
         } else {
           stack_push(&s, &op_false);
@@ -497,13 +497,6 @@ bool evaluate_postfix_expression(zval* arr, struct ast_node* tok) {
         break;
       case TYPE_OPERAND:
         stack_push(&s, tok);
-        /* TODO hack for now, place under value */
-        if (tok->type == AST_SELECTOR) {
-          while (tok->next != NULL && tok->next->type == AST_SELECTOR) {
-            /* skip putting following selectors on stack */
-            tok = tok->next;
-          }
-        }
         break;
       case TYPE_PAREN:
         /* there should be no parens in the postfix expression */

--- a/src/jsonpath/parser.c
+++ b/src/jsonpath/parser.c
@@ -621,6 +621,8 @@ void free_ast_nodes(struct ast_node* head) {
 
   if (head->type == AST_EXPR) {
     free_ast_nodes(head->data.d_expression.head);
+  } else if (head->type == AST_OPERAND) {
+    free_ast_nodes(head->data.d_operand.head);
   }
 
   efree((void*)head);

--- a/src/jsonpath/parser.h
+++ b/src/jsonpath/parser.h
@@ -6,7 +6,6 @@
 #include <string.h>
 
 #include "lexer.h"
-#include "php.h"
 
 #define PARSE_BUF_LEN 50
 
@@ -76,15 +75,12 @@ typedef struct {
   char msg[PARSE_BUF_LEN];
 } parse_error;
 
-bool evaluate_postfix_expression(zval* arr, struct ast_node* tok);
-
-bool evaluate_subexpression(zval* array, enum ast_type operator_type, struct ast_node* lh_operand,
-                            struct ast_node* rh_operand);
-
 bool build_parse_tree(lex_token lex_tok[PARSE_BUF_LEN], char lex_tok_values[][PARSE_BUF_LEN], int* lex_idx,
                       int lex_tok_count, struct ast_node* head, parse_error* err);
 bool sanity_check(lex_token lex_tok[], int lex_tok_count);
 void free_ast_nodes(struct ast_node* head);
 bool validate_parse_tree(struct ast_node* head);
+operator_type get_token_type(enum ast_type);
+bool is_unary(enum ast_type type);
 
 #endif /* PARSER_H */

--- a/src/jsonpath/parser.h
+++ b/src/jsonpath/parser.h
@@ -31,6 +31,7 @@ enum ast_type {
   AST_LT,
   AST_LTE,
   AST_NE,
+  AST_OPERAND,
   AST_OR,
   AST_PAREN_LEFT,
   AST_PAREN_RIGHT,
@@ -48,6 +49,9 @@ union ast_node_data {
   struct {
     struct ast_node* head;
   } d_expression;
+  struct {
+    struct ast_node* head;
+  } d_operand;
   struct {
     int count;
     int indexes[10]; /* todo check for max */


### PR DESCRIPTION
@crocodele The following expression value (operands) types are supported:

- child selector
- number
- string
- regpattern

This PR aims to support jsonpaths within expressions, which requires fully recursive value evaluation.

Example:
```
$..book[?(@.author==$.authors[3])]
```