### PR TITLE
Support JSONPath subexpressions

### DIFF
--- a/jsonpath.c
+++ b/jsonpath.c
@@ -82,7 +82,7 @@ PHP_METHOD(JsonPath, find) {
 
   array_init(return_value);
 
-  eval_ast(search_target, head.next, return_value);
+  eval_ast(search_target, search_target, head.next, return_value);
 
   free_ast_nodes(head.next);
 

--- a/src/jsonpath/interpreter.c
+++ b/src/jsonpath/interpreter.c
@@ -335,12 +335,12 @@ bool evaluate_subexpression(zval* arr_head, zval* arr_cur, enum ast_type operato
 
   /* clean up strings allocated in operand_to_zval() */
 
-  if (rh_operand->type == AST_LITERAL && val_rh != NULL) {
+  if (rh_operand->data.d_value.head->type == AST_LITERAL) {
     zval_ptr_dtor(val_rh);
   }
 
 FREE_LHS:
-  if (lh_operand->type == AST_LITERAL) {
+  if (lh_operand->data.d_value.head->type == AST_LITERAL) {
     zval_ptr_dtor(val_lh);
   }
 

--- a/src/jsonpath/interpreter.c
+++ b/src/jsonpath/interpreter.c
@@ -287,16 +287,18 @@ bool evaluate_subexpression(zval* arr_head, zval* arr_cur, enum ast_type operato
     return false;
   }
 
+  bool ret = false;
+
   if (operator_type == AST_ISSET) {
-    return val_lh != NULL;
+    ret = val_lh != NULL;
+    goto FREE_LHS;
   }
 
   zval* val_rh = operand_to_zval(rh_operand, &tmp_rh, arr_head, arr_cur);
   if (val_rh == NULL) {
-    return false;
+    ret = false;
+    goto FREE_LHS;
   }
-
-  bool ret;
 
   switch (operator_type) {
     case AST_EQ:
@@ -332,11 +334,14 @@ bool evaluate_subexpression(zval* arr_head, zval* arr_cur, enum ast_type operato
   }
 
   /* clean up strings allocated in operand_to_zval() */
+
+  if (rh_operand->type == AST_LITERAL && val_rh != NULL) {
+    zval_ptr_dtor(val_rh);
+  }
+
+FREE_LHS:
   if (lh_operand->type == AST_LITERAL) {
     zval_ptr_dtor(val_lh);
-  }
-  if (rh_operand->type == AST_LITERAL) {
-    zval_ptr_dtor(val_rh);
   }
 
   return ret;

--- a/src/jsonpath/interpreter.c
+++ b/src/jsonpath/interpreter.c
@@ -3,45 +3,47 @@
 #include <ext/pcre/php_pcre.h>
 
 #include "lexer.h"
+#include "stack.h"
 
 int compare(zval* lh, zval* rh);
 bool compare_rgxp(zval* lh, zval* rh);
-void copy_result_to_return_value(zval* arr, zval* return_value);
-bool evaluate_subexpression(zval* arr, enum ast_type operator_type, struct ast_node* lh_operand,
+bool evaluate_postfix_expression(zval* arr_head, zval* arr_cur, struct ast_node* tok);
+bool evaluate_subexpression(zval* arr_head, zval* arr_cur, enum ast_type operator_type, struct ast_node* lh_operand,
                             struct ast_node* rh_operand);
-void exec_expression(zval* arr, struct ast_node* tok, zval* return_value);
-void exec_index_filter(zval* arr, struct ast_node* tok, zval* return_value);
-void exec_recursive_descent(zval* arr, struct ast_node* tok, zval* return_value);
-void exec_selector(zval* arr, struct ast_node* tok, zval* return_value);
-zval* exec_selector_iterative(zval* arr, struct ast_node* tok);
-void exec_slice(zval* arr, struct ast_node* tok, zval* return_value);
-void exec_wildcard(zval* arr, struct ast_node* tok, zval* return_value);
-zval* operand_to_zval(struct ast_node* src, zval* tmp_dest, zval* arr);
+void exec_expression(zval* arr_head, zval* arr_cur, struct ast_node* tok, zval* return_value);
+void exec_index_filter(zval* arr_head, zval* arr_cur, struct ast_node* tok, zval* return_value);
+void exec_recursive_descent(zval* arr_head, zval* arr_cur, struct ast_node* tok, zval* return_value);
+void exec_selector(zval* arr_head, zval* arr_cur, struct ast_node* tok, zval* return_value);
+void exec_slice(zval* arr_head, zval* arr_cur, struct ast_node* tok, zval* return_value);
+void exec_wildcard(zval* arr_head, zval* arr_cur, struct ast_node* tok, zval* return_value);
+zval* operand_to_zval(struct ast_node* src, zval* tmp_dest, zval* arr_head, zval* arr_cur);
+bool break_if_result_found(zval* return_value);
+void copy_result_or_continue(zval* arr_head, zval* arr_cur, struct ast_node* tok, zval* return_value);
 
-void eval_ast(zval* arr, struct ast_node* tok, zval* return_value) {
+void eval_ast(zval* arr_head, zval* arr_cur, struct ast_node* tok, zval* return_value) {
   while (tok != NULL) {
     switch (tok->type) {
       case AST_INDEX_LIST:
-        exec_index_filter(arr, tok, return_value);
+        exec_index_filter(arr_head, arr_cur, tok, return_value);
         return;
       case AST_INDEX_SLICE:
-        exec_slice(arr, tok, return_value);
+        exec_slice(arr_head, arr_cur, tok, return_value);
         return;
       case AST_ROOT:
         tok = tok->next;
         break;
       case AST_RECURSE:
         tok = tok->next;
-        exec_recursive_descent(arr, tok, return_value);
+        exec_recursive_descent(arr_head, arr_cur, tok, return_value);
         return;
       case AST_SELECTOR:
-        exec_selector(arr, tok, return_value);
+        exec_selector(arr_head, arr_cur, tok, return_value);
         return;
       case AST_WILD_CARD:
-        exec_wildcard(arr, tok, return_value);
+        exec_wildcard(arr_head, arr_cur, tok, return_value);
         return;
       case AST_EXPR:
-        exec_expression(arr, tok, return_value);
+        exec_expression(arr_head, arr_cur, tok, return_value);
         return;
       default:
         assert(0);
@@ -50,32 +52,21 @@ void eval_ast(zval* arr, struct ast_node* tok, zval* return_value) {
   }
 }
 
-void copy_result_to_return_value(zval* arr, zval* return_value) {
-  zval tmp;
-  ZVAL_COPY_VALUE(&tmp, arr);
-  zval_copy_ctor(&tmp);
-  add_next_index_zval(return_value, &tmp);
-}
-
-void exec_selector(zval* arr, struct ast_node* tok, zval* return_value) {
-  if (arr == NULL || Z_TYPE_P(arr) != IS_ARRAY) {
+void exec_selector(zval* arr_head, zval* arr_cur, struct ast_node* tok, zval* return_value) {
+  if (arr_cur == NULL || Z_TYPE_P(arr_cur) != IS_ARRAY) {
     return;
   }
 
-  if ((arr = zend_hash_str_find(HASH_OF(arr), tok->data.d_selector.value, strlen(tok->data.d_selector.value))) ==
-      NULL) {
+  if ((arr_cur = zend_hash_str_find(HASH_OF(arr_cur), tok->data.d_selector.value,
+                                    strlen(tok->data.d_selector.value))) == NULL) {
     return;
   }
 
-  if (tok->next != NULL) {
-    eval_ast(arr, tok->next, return_value);
-  } else {
-    copy_result_to_return_value(arr, return_value);
-  }
+  copy_result_or_continue(arr_head, arr_cur, tok, return_value);
 }
 
-void exec_wildcard(zval* arr, struct ast_node* tok, zval* return_value) {
-  if (arr == NULL || Z_TYPE_P(arr) != IS_ARRAY) {
+void exec_wildcard(zval* arr_head, zval* arr_cur, struct ast_node* tok, zval* return_value) {
+  if (arr_cur == NULL || Z_TYPE_P(arr_cur) != IS_ARRAY) {
     return;
   }
 
@@ -84,18 +75,17 @@ void exec_wildcard(zval* arr, struct ast_node* tok, zval* return_value) {
   zend_string* key;
   zend_ulong num_key;
 
-  ZEND_HASH_FOREACH_KEY_VAL(HASH_OF(arr), num_key, key, data) {
-    if (tok->next == NULL) {
-      copy_result_to_return_value(data, return_value);
-    } else {
-      eval_ast(data, tok->next, return_value);
+  ZEND_HASH_FOREACH_KEY_VAL(HASH_OF(arr_cur), num_key, key, data) {
+    copy_result_or_continue(arr_head, data, tok, return_value);
+    if (break_if_result_found(return_value)) {
+      break;
     }
   }
   ZEND_HASH_FOREACH_END();
 }
 
-void exec_recursive_descent(zval* arr, struct ast_node* tok, zval* return_value) {
-  if (arr == NULL || Z_TYPE_P(arr) != IS_ARRAY) {
+void exec_recursive_descent(zval* arr_head, zval* arr_cur, struct ast_node* tok, zval* return_value) {
+  if (arr_cur == NULL || Z_TYPE_P(arr_cur) != IS_ARRAY) {
     return;
   }
 
@@ -104,32 +94,33 @@ void exec_recursive_descent(zval* arr, struct ast_node* tok, zval* return_value)
   zend_string* key;
   zend_ulong num_key;
 
-  eval_ast(arr, tok, return_value);
+  eval_ast(arr_head, arr_cur, tok, return_value);
 
-  ZEND_HASH_FOREACH_KEY_VAL(HASH_OF(arr), num_key, key, data) { exec_recursive_descent(data, tok, return_value); }
+  ZEND_HASH_FOREACH_KEY_VAL(HASH_OF(arr_cur), num_key, key, data) {
+    exec_recursive_descent(arr_head, data, tok, return_value);
+  }
   ZEND_HASH_FOREACH_END();
 }
 
-void exec_index_filter(zval* arr, struct ast_node* tok, zval* return_value) {
+void exec_index_filter(zval* arr_head, zval* arr_cur, struct ast_node* tok, zval* return_value) {
   for (int i = 0; i < tok->data.d_list.count; i++) {
     if (tok->data.d_list.indexes[i] < 0) {
-      tok->data.d_list.indexes[i] = zend_hash_num_elements(HASH_OF(arr)) - abs(tok->data.d_list.indexes[i]);
+      tok->data.d_list.indexes[i] = zend_hash_num_elements(HASH_OF(arr_cur)) - abs(tok->data.d_list.indexes[i]);
     }
     zval* data;
-    if ((data = zend_hash_index_find(HASH_OF(arr), tok->data.d_list.indexes[i])) != NULL) {
-      if (tok->next == NULL) {
-        copy_result_to_return_value(data, return_value);
-      } else {
-        eval_ast(data, tok->next, return_value);
+    if ((data = zend_hash_index_find(HASH_OF(arr_cur), tok->data.d_list.indexes[i])) != NULL) {
+      copy_result_or_continue(arr_head, data, tok, return_value);
+      if (break_if_result_found(return_value)) {
+        break;
       }
     }
   }
 }
 
-void exec_slice(zval* arr, struct ast_node* tok, zval* return_value) {
+void exec_slice(zval* arr_head, zval* arr_cur, struct ast_node* tok, zval* return_value) {
   zval* data;
 
-  int data_length = zend_hash_num_elements(HASH_OF(arr));
+  int data_length = zend_hash_num_elements(HASH_OF(arr_cur));
 
   int range_start = tok->data.d_list.indexes[0];
   int range_end = tok->data.d_list.count > 1 ? tok->data.d_list.indexes[1] : INT_MAX;
@@ -173,11 +164,10 @@ void exec_slice(zval* arr, struct ast_node* tok, zval* return_value) {
     }
 
     for (int i = range_start; i < range_end; i += range_step) {
-      if ((data = zend_hash_index_find(HASH_OF(arr), i)) != NULL) {
-        if (tok->next == NULL) {
-          copy_result_to_return_value(data, return_value);
-        } else {
-          eval_ast(data, tok->next, return_value);
+      if ((data = zend_hash_index_find(HASH_OF(arr_cur), i)) != NULL) {
+        copy_result_or_continue(arr_head, data, tok, return_value);
+        if (break_if_result_found(return_value)) {
+          break;
         }
       }
     }
@@ -188,54 +178,30 @@ void exec_slice(zval* arr, struct ast_node* tok, zval* return_value) {
     }
 
     for (int i = range_start; i > range_end; i += range_step) {
-      if ((data = zend_hash_index_find(HASH_OF(arr), i)) != NULL) {
-        if (tok->next == NULL) {
-          copy_result_to_return_value(data, return_value);
-        } else {
-          eval_ast(data, tok->next, return_value);
+      if ((data = zend_hash_index_find(HASH_OF(arr_cur), i)) != NULL) {
+        copy_result_or_continue(arr_head, data, tok, return_value);
+        if (break_if_result_found(return_value)) {
+          break;
         }
       }
     }
   }
 }
 
-void exec_expression(zval* arr, struct ast_node* tok, zval* return_value) {
+void exec_expression(zval* arr_head, zval* arr_cur, struct ast_node* tok, zval* return_value) {
   zend_ulong num_key;
   zend_string* key;
   zval* data;
 
-  ZEND_HASH_FOREACH_KEY_VAL(HASH_OF(arr), num_key, key, data) {
-    if (evaluate_postfix_expression(data, tok->data.d_expression.head)) {
-      if (tok->next == NULL) {
-        copy_result_to_return_value(data, return_value);
-      } else {
-        eval_ast(data, tok->next, return_value);
+  ZEND_HASH_FOREACH_KEY_VAL(HASH_OF(arr_cur), num_key, key, data) {
+    if (evaluate_postfix_expression(arr_head, data, tok->data.d_expression.head)) {
+      copy_result_or_continue(arr_head, data, tok, return_value);
+      if (break_if_result_found(return_value)) {
+        break;
       }
     }
   }
   ZEND_HASH_FOREACH_END();
-}
-
-/* This does the same thing as exec_selector_iterative except we don't */
-/* continue recursing after a contiguous sequence of AST_SELECTOR has been */
-/* read. */
-zval* exec_selector_iterative(zval* arr, struct ast_node* tok) {
-  if (arr == NULL || Z_TYPE_P(arr) != IS_ARRAY) {
-    return NULL;
-  }
-
-  zval* data;
-
-  while (tok->type == AST_SELECTOR) {
-    if ((data = zend_hash_str_find(HASH_OF(arr), tok->data.d_selector.value, strlen(tok->data.d_selector.value))) ==
-        NULL) {
-      return NULL;
-    }
-    arr = data;
-    tok = tok->next;
-  }
-
-  return arr;
 }
 
 int compare(zval* lh, zval* rh) {
@@ -270,41 +236,62 @@ bool compare_rgxp(zval* lh, zval* rh) {
   return Z_LVAL(retval) > 0;
 }
 
-zval* operand_to_zval(struct ast_node* src, zval* tmp_dest, zval* arr) {
-  if (src->type == AST_SELECTOR) {
-    return exec_selector_iterative(arr, src);
-  } else if (src->type == AST_LITERAL) {
-    ZVAL_STRING(tmp_dest, src->data.d_literal.value);
-    return tmp_dest;
-  } else {
-    /* todo: runtime error */
-    return NULL;
+zval* operand_to_zval(struct ast_node* src, zval* tmp_dest, zval* arr_head, zval* arr_cur) {
+  switch (src->data.d_value.head->type) {
+    case AST_BOOL:
+      ZVAL_BOOL(tmp_dest, src->data.d_value.head->data.d_literal.value_bool);
+      return tmp_dest;
+    case AST_LITERAL:
+      ZVAL_STRING(tmp_dest, src->data.d_value.head->data.d_literal.value);
+      return tmp_dest;
+    case AST_ROOT:
+      ZVAL_INDIRECT(tmp_dest, NULL);
+      eval_ast(arr_head, arr_head, src->data.d_value.head, tmp_dest);
+      return Z_INDIRECT_P(tmp_dest);
+    case AST_SELECTOR:
+      ZVAL_INDIRECT(tmp_dest, NULL);
+      eval_ast(arr_head, arr_cur, src->data.d_value.head, tmp_dest);
+      return Z_INDIRECT_P(tmp_dest);
+    default:
+      assert(0);
+      return NULL;
   }
 }
 
-bool evaluate_subexpression(zval* arr, enum ast_type operator_type, struct ast_node* lh_operand,
-                            struct ast_node* rh_operand) {
-  switch (operator_type) {
-    case AST_OR:
-      return lh_operand->data.d_literal.value_bool || rh_operand->data.d_literal.value_bool;
-    case AST_AND:
-      return lh_operand->data.d_literal.value_bool && rh_operand->data.d_literal.value_bool;
-    case AST_ISSET:
-      return exec_selector_iterative(arr, lh_operand) != NULL;
-    default:
-      /* noop */
-      break;
-  }
+bool break_if_result_found(zval* return_value) {
+  return Z_TYPE_P(return_value) == IS_INDIRECT && Z_INDIRECT_P(return_value) != NULL;
+}
 
+void copy_result_or_continue(zval* arr_head, zval* arr_cur, struct ast_node* tok, zval* return_value) {
+  if (tok->next == NULL) {
+    if (Z_TYPE_P(return_value) == IS_ARRAY) {
+      zval tmp;
+      ZVAL_COPY_VALUE(&tmp, arr_cur);
+      zval_copy_ctor(&tmp);
+      add_next_index_zval(return_value, &tmp);
+    } else if (Z_TYPE_P(return_value) == IS_INDIRECT) {
+      ZVAL_INDIRECT(return_value, arr_cur);
+    }
+  } else {
+    eval_ast(arr_head, arr_cur, tok->next, return_value);
+  }
+}
+
+bool evaluate_subexpression(zval* arr_head, zval* arr_cur, enum ast_type operator_type, struct ast_node* lh_operand,
+                            struct ast_node* rh_operand) {
   /* use stack-allocated zvals in order to avoid malloc, if possible */
   zval tmp_lh = {0}, tmp_rh = {0};
 
-  zval* val_lh = operand_to_zval(lh_operand, &tmp_lh, arr);
+  zval* val_lh = operand_to_zval(lh_operand, &tmp_lh, arr_head, arr_cur);
   if (val_lh == NULL) {
     return false;
   }
 
-  zval* val_rh = operand_to_zval(rh_operand, &tmp_rh, arr);
+  if (operator_type == AST_ISSET) {
+    return val_lh != NULL;
+  }
+
+  zval* val_rh = operand_to_zval(rh_operand, &tmp_rh, arr_head, arr_cur);
   if (val_rh == NULL) {
     return false;
   }
@@ -324,6 +311,12 @@ bool evaluate_subexpression(zval* arr, enum ast_type operator_type, struct ast_n
     case AST_LTE:
       ret = compare(val_lh, val_rh) <= 0;
       break;
+    case AST_OR:
+      ret = (Z_TYPE_P(val_lh) == IS_TRUE) || (Z_TYPE_P(val_rh) == IS_TRUE);
+      break;
+    case AST_AND:
+      ret = (Z_TYPE_P(val_lh) == IS_TRUE) && (Z_TYPE_P(val_rh) == IS_TRUE);
+      break;
     case AST_GT:
       ret = compare(val_lh, val_rh) > 0;
       break;
@@ -338,8 +331,72 @@ bool evaluate_subexpression(zval* arr, enum ast_type operator_type, struct ast_n
       break;
   }
 
-  zval_ptr_dtor(val_lh);
-  zval_ptr_dtor(val_rh);
+  /* clean up strings allocated in operand_to_zval() */
+  if (lh_operand->type == AST_LITERAL) {
+    zval_ptr_dtor(val_lh);
+  }
+  if (rh_operand->type == AST_LITERAL) {
+    zval_ptr_dtor(val_rh);
+  }
 
   return ret;
+}
+
+bool evaluate_postfix_expression(zval* arr_head, zval* arr_cur, struct ast_node* tok) {
+  stack s;
+  stack_init(&s);
+  struct ast_node* expr_lh;
+  struct ast_node* expr_rh;
+
+  /* op_true & op_false temporarily store subexpressions results on the stack */
+  struct ast_node op_true = {0}, bool_true = {0};
+
+  op_true.type = AST_VALUE;
+  op_true.data.d_value.head = &bool_true;
+  op_true.data.d_value.head->type = AST_BOOL;
+  op_true.data.d_value.head->data.d_literal.value_bool = true;
+
+  struct ast_node op_false = {0}, bool_false = {0};
+
+  op_false.type = AST_VALUE;
+  op_false.data.d_value.head = &bool_false;
+  op_false.data.d_value.head->type = AST_BOOL;
+  op_false.data.d_value.head->data.d_literal.value_bool = false;
+
+  while (tok != NULL) {
+    switch (get_token_type(tok->type)) {
+      case TYPE_OPERATOR:
+
+        if (is_unary(tok->type)) {
+          expr_rh = NULL;
+          expr_lh = stack_top(&s);
+        } else {
+          expr_rh = stack_top(&s);
+          stack_pop(&s);
+          expr_lh = stack_top(&s);
+        }
+
+        stack_pop(&s);
+
+        if (evaluate_subexpression(arr_head, arr_cur, tok->type, expr_lh, expr_rh)) {
+          stack_push(&s, &op_true);
+        } else {
+          stack_push(&s, &op_false);
+        }
+
+        break;
+      case TYPE_OPERAND:
+        stack_push(&s, tok);
+        break;
+      case TYPE_PAREN:
+        /* there should be no parens in the postfix expression */
+        assert(0);
+    }
+
+    tok = tok->next;
+  }
+
+  expr_lh = stack_top(&s);
+
+  return expr_lh->data.d_value.head->data.d_literal.value_bool;
 }

--- a/src/jsonpath/interpreter.h
+++ b/src/jsonpath/interpreter.h
@@ -4,6 +4,6 @@
 #include "parser.h"
 #include "php.h"
 
-void eval_ast(zval* arr, struct ast_node* tok, zval* return_value);
+void eval_ast(zval* arr_head, zval* arr_cur, struct ast_node* tok, zval* return_value);
 
 #endif /* INTERPRETER_H */

--- a/src/jsonpath/parser.h
+++ b/src/jsonpath/parser.h
@@ -6,7 +6,6 @@
 #include <string.h>
 
 #include "lexer.h"
-#include "php.h"
 
 #define PARSE_BUF_LEN 50
 
@@ -39,7 +38,8 @@ enum ast_type {
   AST_ROOT,
   AST_SELECTOR,
   AST_WILD_CARD,
-  AST_HEAD
+  AST_HEAD,
+  AST_VALUE
 };
 
 extern const char* AST_STR[];
@@ -60,6 +60,9 @@ union ast_node_data {
     char value[PARSE_BUF_LEN];
     bool child_scope; /* @.selector if true, else $.selector */
   } d_selector;
+  struct {
+    struct ast_node* head;
+  } d_value;
 };
 
 struct ast_node {
@@ -72,15 +75,12 @@ typedef struct {
   char msg[PARSE_BUF_LEN];
 } parse_error;
 
-bool evaluate_postfix_expression(zval* arr, struct ast_node* tok);
-
-bool evaluate_subexpression(zval* array, enum ast_type operator_type, struct ast_node* lh_operand,
-                            struct ast_node* rh_operand);
-
 bool build_parse_tree(lex_token lex_tok[PARSE_BUF_LEN], char lex_tok_values[][PARSE_BUF_LEN], int* lex_idx,
                       int lex_tok_count, struct ast_node* head, parse_error* err);
 bool sanity_check(lex_token lex_tok[], int lex_tok_count);
 void free_ast_nodes(struct ast_node* head);
 bool validate_parse_tree(struct ast_node* head);
+operator_type get_token_type(enum ast_type);
+bool is_unary(enum ast_type type);
 
 #endif /* PARSER_H */

--- a/tests/expressions/002.phpt
+++ b/tests/expressions/002.phpt
@@ -1,0 +1,68 @@
+--TEST--
+Test JSONPath query within JSONPath expression
+--SKIPIF--
+<?php if (!extension_loaded("jsonpath")) print "skip"; ?>
+--FILE--
+<?php
+
+$json = <<<HEREDOC
+{ 
+    "authors": [
+        "Nigel Rees",
+        "J. R. R. Tolkien",
+        "Herman Melville",
+        "Evelyn Waugh"
+    ],
+    "store": {
+        "book": [
+            {
+                "category": "reference",
+                "author": "Nigel Rees",
+                "title": "Sayings of the Century",
+                "price": 8.95
+            },
+            { 
+                "category": "poetry",
+                "author": "Herman Melville",
+                "title": "Timoleon",
+                "isbn": "978-0521034135",
+                "price": 42.99
+            },
+            { 
+                "category": "fiction",
+                "author": "Evelyn Waugh",
+                "title": "Sword of Honour",
+                "price": 12.99
+            },
+            { 
+                "category": "fiction",
+                "author": "Herman Melville",
+                "title": "Moby Dick",
+                "isbn": "0-553-21311-3",
+                "price": 8.99
+            },
+            { 
+                "category": "fiction",
+                "author": "J. R. R. Tolkien",
+                "title": "The Lord of the Rings",
+                "isbn": "0-395-19395-8",
+                "price": 22.99
+            }
+        ]
+    }
+}
+HEREDOC;
+
+$json = json_decode($json, true);
+
+$jsonPath = new JsonPath();
+
+print_r($jsonPath->find($json, '$..book[?(@.author==$.authors[2])].isbn'));
+
+?>
+--EXPECT--
+Array
+(
+    [0] => 978-0521034135
+    [1] => 0-553-21311-3
+)

--- a/tests/expressions/002.phpt
+++ b/tests/expressions/002.phpt
@@ -5,55 +5,54 @@ Test JSONPath query within JSONPath expression
 --FILE--
 <?php
 
-$json = <<<HEREDOC
-{ 
-    "authors": [
-        "Nigel Rees",
-        "J. R. R. Tolkien",
-        "Herman Melville",
-        "Evelyn Waugh"
-    ],
-    "store": {
-        "book": [
-            {
-                "category": "reference",
-                "author": "Nigel Rees",
-                "title": "Sayings of the Century",
-                "price": 8.95
-            },
-            { 
-                "category": "poetry",
-                "author": "Herman Melville",
-                "title": "Timoleon",
-                "isbn": "978-0521034135",
-                "price": 42.99
-            },
-            { 
-                "category": "fiction",
-                "author": "Evelyn Waugh",
-                "title": "Sword of Honour",
-                "price": 12.99
-            },
-            { 
-                "category": "fiction",
-                "author": "Herman Melville",
-                "title": "Moby Dick",
-                "isbn": "0-553-21311-3",
-                "price": 8.99
-            },
-            { 
-                "category": "fiction",
-                "author": "J. R. R. Tolkien",
-                "title": "The Lord of the Rings",
-                "isbn": "0-395-19395-8",
-                "price": 22.99
-            }
-        ]
-    }
-}
-HEREDOC;
-
-$json = json_decode($json, true);
+$json = array(
+    'authors' =>
+    array(
+        'Nigel Rees',
+        'J. R. R. Tolkien',
+        'Herman Melville',
+        'Evelyn Waugh',
+    ),
+    'store' =>
+    array(
+        'book' =>
+        array(
+            array(
+                'category' => 'reference',
+                'author' => 'Nigel Rees',
+                'title' => 'Sayings of the Century',
+                'price' => 8.95,
+            ),
+            array(
+                'category' => 'poetry',
+                'author' => 'Herman Melville',
+                'title' => 'Timoleon',
+                'isbn' => '978-0521034135',
+                'price' => 42.99,
+            ),
+            array(
+                'category' => 'fiction',
+                'author' => 'Evelyn Waugh',
+                'title' => 'Sword of Honour',
+                'price' => 12.99,
+            ),
+            array(
+                'category' => 'fiction',
+                'author' => 'Herman Melville',
+                'title' => 'Moby Dick',
+                'isbn' => '0-553-21311-3',
+                'price' => 8.99,
+            ),
+            array(
+                'category' => 'fiction',
+                'author' => 'J. R. R. Tolkien',
+                'title' => 'The Lord of the Rings',
+                'isbn' => '0-395-19395-8',
+                'price' => 22.99,
+            )
+        )
+    )
+);
 
 $jsonPath = new JsonPath();
 


### PR DESCRIPTION
@crocodele The following expression value (operands) types are supported:

- child selector
- number
- string
- regpattern

This PR aims to support jsonpaths within expressions, which requires fully recursive value evaluation.

Example:
```
$..book[?(@.author==$.authors[3])]
```

Changes:
- Move `evaluate_postfix_expression` from `parser.c` to `interpreter.c`
- Wrap expression values with an `AST_VALUE` struct. This makes it easier for the interpreter to know what nodes to send to `evaluate_ast`.
- Support JSONPaths as expression values. When the interpreter encounters a root selector `$` in an expression, it knows to send the JSONPath expression back to `evaluate_ast`. This requires `evaluate_ast` to have a reference to the beginning of the search target array (in addition to the current array pointer) so that it can evaluate a JSONPath subexpression from the beginning at any given point in the function call tree.