### PR TITLE
Revert "Mark filter test 041 as passing following recent changes"

### DIFF
--- a/tests/comparison_filter/041.phpt
+++ b/tests/comparison_filter/041.phpt
@@ -74,3 +74,5 @@ array(1) {
     string(5) "value"
   }
 }
+--XFAIL--
+Requires more work on filter expressions


### PR DESCRIPTION
Reverts supermetrics/php-ext-jsonpath#35

Seems this test behaves in different ways in PHP 7.4 (fails) and PHP 8.0 (passes).