### PR TITLE
Fix isset parsing edge cases

### DIFF
--- a/tests/comparison_filter/046.phpt
+++ b/tests/comparison_filter/046.phpt
@@ -35,5 +35,3 @@ array(1) {
     int(42)
   }
 }
---XFAIL--
-This kind of root reference is not currently supported

--- a/tests/isset/001.phpt
+++ b/tests/isset/001.phpt
@@ -1,0 +1,45 @@
+--TEST--
+Test isset as single operator in expression
+--SKIPIF--
+<?php if (!extension_loaded("jsonpath")) print "skip"; ?>
+--FILE--
+<?php
+
+$obj = array(
+    'book' =>
+    array(
+        array(
+            'category' => 'reference',
+            'author' => 'Nigel Rees',
+            'title' => 'Sayings of the Century',
+            'price' => 8.9499999999999993,
+            'id' =>
+            array(
+                'isbn' => '684832674',
+            )
+        )
+    )
+);
+
+$jsonPath = new JsonPath();
+
+print_r($jsonPath->find($obj, '$.book[?(@["id"]["isbn"])]'));
+
+?>
+--EXPECT--
+Array
+(
+    [0] => Array
+        (
+            [category] => reference
+            [author] => Nigel Rees
+            [title] => Sayings of the Century
+            [price] => 8.95
+            [id] => Array
+                (
+                    [isbn] => 684832674
+                )
+
+        )
+
+)

--- a/tests/isset/002.phpt
+++ b/tests/isset/002.phpt
@@ -1,0 +1,55 @@
+--TEST--
+Test isset in conjunction with a second subexpression
+--SKIPIF--
+<?php if (!extension_loaded("jsonpath")) print "skip"; ?>
+--FILE--
+<?php
+
+$obj = array(
+    'book' =>
+    array(
+        array(
+            'category' => 'fiction',
+            'author' => 'J. R. R. Tolkien',
+            'title' => 'The Lord of the Rings',
+            'price' => 22.99,
+            'id' =>
+            array(
+                'isbn' => '0-395-19395-8',
+            )
+        ),
+        array(
+            'category' => 'reference',
+            'author' => 'Nigel Rees',
+            'title' => 'Sayings of the Century',
+            'price' => 8.9499999999999993,
+            'id' =>
+            array(
+                'isbn' => '684832674',
+            )
+        )
+    )
+);
+
+$jsonPath = new JsonPath();
+
+print_r($jsonPath->find($obj, '$.book[?(@["id"]["isbn"] && @.author == "Nigel Rees")]'));
+
+?>
+--EXPECT--
+Array
+(
+    [0] => Array
+        (
+            [category] => reference
+            [author] => Nigel Rees
+            [title] => Sayings of the Century
+            [price] => 8.95
+            [id] => Array
+                (
+                    [isbn] => 684832674
+                )
+
+        )
+
+)

--- a/tests/isset/003.phpt
+++ b/tests/isset/003.phpt
@@ -1,0 +1,55 @@
+--TEST--
+Ensure AST selector on right side of AND expression is not identified as ISSET
+--SKIPIF--
+<?php if (!extension_loaded("jsonpath")) print "skip"; ?>
+--FILE--
+<?php
+
+$obj = array(
+    'book' =>
+    array(
+        array(
+            'category' => 'fiction',
+            'author' => 'J. R. R. Tolkien',
+            'title' => 'The Lord of the Rings',
+            'price' => 22.99,
+            'id' =>
+            array(
+                'isbn' => '0-395-19395-8',
+            )
+        ),
+        array(
+            'category' => 'reference',
+            'author' => 'Nigel Rees',
+            'title' => 'Sayings of the Century',
+            'price' => 8.9499999999999993,
+            'id' =>
+            array(
+                'isbn' => '684832674',
+            )
+        )
+    )
+);
+
+$jsonPath = new JsonPath();
+
+print_r($jsonPath->find($obj, '$.book[?(@["id"]["isbn"] && "Nigel Rees" == @.author)]'));
+
+?>
+--EXPECT--
+Array
+(
+    [0] => Array
+        (
+            [category] => reference
+            [author] => Nigel Rees
+            [title] => Sayings of the Century
+            [price] => 8.95
+            [id] => Array
+                (
+                    [isbn] => 684832674
+                )
+
+        )
+
+)


### PR DESCRIPTION
@crocodele 

Previously, the parser only checked if a selector was bordered on the
right side by a paren, OR operator or AND operator in order to determine
if the selector was an isset operand. This lead to edge cases where
selectors on the right side of binary expressions were incorrectly
getting treated as isset operands.

This commit implements a more robust check for isset operands.

As a result of this work, `tests/comparison_filter/046.phpt` now works.