### PR TITLE
Fix tests/comparison_filter/{022,002}.phpt

### DIFF
--- a/src/jsonpath/interpreter.c
+++ b/src/jsonpath/interpreter.c
@@ -189,6 +189,10 @@ void exec_slice(zval* arr_head, zval* arr_cur, struct ast_node* tok, zval* retur
 }
 
 void exec_expression(zval* arr_head, zval* arr_cur, struct ast_node* tok, zval* return_value) {
+  if (arr_cur == NULL || Z_TYPE_P(arr_cur) != IS_ARRAY) {
+    return;
+  }
+
   zend_ulong num_key;
   zend_string* key;
   zval* data;

--- a/src/jsonpath/parser.c
+++ b/src/jsonpath/parser.c
@@ -379,6 +379,12 @@ bool validate_parse_tree(struct ast_node* head) {
           return false;
         }
         break;
+      case AST_EXPR:
+        if (cur->data.d_expression.head == NULL) {
+          zend_throw_exception(spl_ce_RuntimeException, "Filter expressions may not be empty.", 0);
+          return false;
+        }
+        break;
       default:
         break;
     }

--- a/tests/comparison_filter/002.phpt
+++ b/tests/comparison_filter/002.phpt
@@ -51,25 +51,23 @@ Assertion 1
 array(3) {
   [0]=>
   array(2) {
-    ["name"]=>
-    string(7) "another"
     ["id"]=>
     int(3)
+    ["name"]=>
+    string(7) "another"
   }
   [1]=>
   array(2) {
-    ["name"]=>
-    string(4) "more"
     ["id"]=>
     int(4)
+    ["name"]=>
+    string(4) "more"
   }
   [2]=>
   array(2) {
-    ["name"]=>
-    string(12) "next to last"
     ["id"]=>
     int(5)
+    ["name"]=>
+    string(12) "next to last"
   }
 }
---XFAIL--
-Requires more work on filter expressions

--- a/tests/comparison_filter/022.phpt
+++ b/tests/comparison_filter/022.phpt
@@ -20,7 +20,9 @@ $result = $jsonPath->find($data, "$[?()]");
 echo "Assertion 1\n";
 var_dump($result);
 ?>
---EXPECT--
-PHP Fatal Error
---XFAIL--
-Now results in a segfault, would be better to error out due to invalid syntax
+--EXPECTF--
+Fatal error: Uncaught RuntimeException: Filter expressions may not be empty. in %s
+Stack trace:
+%s
+%s
+%s


### PR DESCRIPTION
I fixed a segfault raised in `tests/comparison_filter/002.phpt` by `exec_expression`. The test passes after rearranging the expected test output. I'm not sure if the sorting expectations in `tests/comparison_filter/002.phpt` were erroneous, please advise @crocodele.