### PR TITLE
Implement support for numeric selectors

### DIFF
--- a/src/jsonpath/interpreter.c
+++ b/src/jsonpath/interpreter.c
@@ -57,12 +57,20 @@ void exec_selector(zval* arr_head, zval* arr_cur, struct ast_node* tok, zval* re
     return;
   }
 
-  if ((arr_cur = zend_hash_str_find(HASH_OF(arr_cur), tok->data.d_selector.value,
-                                    strlen(tok->data.d_selector.value))) == NULL) {
-    return;
+  zend_ulong idx;
+  int len = strlen(tok->data.d_selector.value);
+
+  if (ZEND_HANDLE_NUMERIC_STR(tok->data.d_selector.value, len, idx)) {
+    /* look up numeric index */
+    arr_cur = zend_hash_index_find(HASH_OF(arr_cur), idx);
+  } else {
+    /* look up string index */
+    arr_cur = zend_hash_str_find(HASH_OF(arr_cur), tok->data.d_selector.value, len);
   }
 
-  copy_result_or_continue(arr_head, arr_cur, tok, return_value);
+  if (arr_cur != NULL) {
+    copy_result_or_continue(arr_head, arr_cur, tok, return_value);
+  }
 }
 
 void exec_wildcard(zval* arr_head, zval* arr_cur, struct ast_node* tok, zval* return_value) {

--- a/tests/comparison_bracket_notation/027.phpt
+++ b/tests/comparison_bracket_notation/027.phpt
@@ -21,5 +21,3 @@ array(1) {
   [0]=>
   string(5) "value"
 }
---XFAIL--
-Numbers as strings need to be converted to integers in index lookups

--- a/tests/comparison_dot_notation/032.phpt
+++ b/tests/comparison_dot_notation/032.phpt
@@ -21,4 +21,7 @@ var_dump($result);
 ?>
 --EXPECT--
 Assertion 1
-bool(false)
+array(1) {
+  [0]=>
+  string(5) "third"
+}

--- a/tests/comparison_dot_notation/033.phpt
+++ b/tests/comparison_dot_notation/033.phpt
@@ -23,5 +23,3 @@ array(1) {
   [0]=>
   string(6) "second"
 }
---XFAIL--
-Requires support for numeric node names


### PR DESCRIPTION
@crocodele This PR implements support for numeric selectors.

This fixes two tests:
* `tests/comparison_bracket_notation/027.phpt`
* `tests/comparison_dot_notation/033.phpt`

The change broke the expected value for `tests/comparison_dot_notation/032.phpt`. Because PHP automatically converts numeric string indexes to integer indexes, I don't think it's possible for this JSONPath implementation to differentiate between a numeric string index and an implicit index.

Observe below how all 3 arrays have an integer index type:

```php
$data1 = [
    "first",
    "second",
    "third",
    "forth",
    "fifth",
];

var_dump(array_keys($data1));

/*
array(5) {
  [0]=>
  int(0)
  [1]=>
  int(1)
  [2]=>
  int(2)
  [3]=>
  int(3)
  [4]=>
  int(4)
}
*/

$data2 = [
    0 => "first",
    1 => "second",
    2 => "third",
    3 => "forth",
    4 => "fifth",
];

var_dump(array_keys($data2));

/*
array(5) {
  [0]=>
  int(0)
  [1]=>
  int(1)
  [2]=>
  int(2)
  [3]=>
  int(3)
  [4]=>
  int(4)
}
*/


$data3 = [
    "0" => "first",
    "1" => "second",
    "2" => "third",
    "3" => "forth",
    "4" => "fifth",
];

var_dump(array_keys($data3));

/*
array(5) {
  [0]=>
  int(0)
  [1]=>
  int(1)
  [2]=>
  int(2)
  [3]=>
  int(3)
  [4]=>
  int(4)
}
*/
```

Because of this, I changed the expected value to match the behavior consistent with `tests/comparison_bracket_notation/027.phpt`.