### PR TITLE
Add code coverage resolving with lcov

### DIFF
--- a/.build-scripts/compile-coverage.sh
+++ b/.build-scripts/compile-coverage.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+phpize
+./configure --enable-jsonpath --enable-code-coverage
+make

--- a/.build-scripts/compile.sh
+++ b/.build-scripts/compile.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 phpize
-./configure --with-jsonpath
+./configure --enable-jsonpath
 make

--- a/.github/workflows/code_coverage.yml
+++ b/.github/workflows/code_coverage.yml
@@ -1,0 +1,74 @@
+name: Calculate code coverage
+
+on:
+    push:
+        branches: [main]
+
+jobs:
+    tests:
+        runs-on: ubuntu-latest
+        name: Build, run tests with code coverage, create badge
+        strategy:
+            fail-fast: false
+            matrix:
+                php: [8.0]
+
+        steps:
+            -   uses: actions/checkout@v2
+
+            -   name: Get branch name (merge)
+                if: github.event_name != 'pull_request'
+                shell: bash
+                run: echo "BRANCH_NAME=$(echo ${GITHUB_REF#refs/heads/} | tr / -)" >> $GITHUB_ENV
+
+            -   name: Get branch name (pull request)
+                if: github.event_name == 'pull_request'
+                shell: bash
+                run: echo "BRANCH_NAME=$(echo ${GITHUB_HEAD_REF} | tr / -)" >> $GITHUB_ENV
+
+            -   name: Install lcov
+                run: sudo apt-get -y install lcov
+
+            -   name: Setup PHP
+                uses: shivammathur/setup-php@v2
+                with:
+                    php-version: "${{ matrix.php }}"
+                    coverage: none
+                    tools: pecl
+
+            -   name: Compile with code coverage support
+                run: ./.build-scripts/compile-coverage.sh
+
+            -   name: Find PHP
+                run: |
+                    TEST_PHP_EXECUTABLE=`make findphp`
+                    echo "Found PHP in: $TEST_PHP_EXECUTABLE"
+                    echo "TEST_PHP_EXECUTABLE=$TEST_PHP_EXECUTABLE" >> $GITHUB_ENV
+          
+            -   name: Define PHP arguments
+                run: |
+                    TEST_PHP_ARGS="-n"
+                    TEST_PHP_ARGS="$TEST_PHP_ARGS -d extension=$PWD/modules/jsonpath.so"
+                    echo "Test PHP arguments: $TEST_PHP_ARGS"
+                    echo "TEST_PHP_ARGS=$TEST_PHP_ARGS" >> $GITHUB_ENV
+          
+            -   name: Run tests
+                run: |
+                    $TEST_PHP_EXECUTABLE $TEST_PHP_ARGS -v
+                    $TEST_PHP_EXECUTABLE -n run-tests.php -q -x --show-diff
+
+            -   name: Generate code coverage report
+                run: |
+                    COVERAGE=$(make lcov-summary |& grep 'lines...' | grep -Eo ' [0-9.]+' | xargs | awk '{print $1}' | xargs printf "%.*f\n" 0)
+                    echo "Code coverage (lines): $COVERAGE"
+                    echo "COVERAGE=$COVERAGE" >> $GITHUB_ENV
+            
+            -   name: Create the badge
+                uses: schneegans/dynamic-badges-action@v1.0.0
+                with:
+                    auth: ${{ secrets.GIST_SECRET }}
+                    gistID: 5ceb08845fe95635fc41af2f4c86c631
+                    filename: php-ext-jsonpath__${{ env.BRANCH_NAME }}.json
+                    label: Coverage
+                    message: ${{ env.COVERAGE }}
+                    color: green

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+# Build
 .deps
 *.lo
 *.la
@@ -14,8 +15,8 @@ config.nice
 config.status
 config.sub
 configure
+configure.ac
 configure.in
-.idea/
 include
 install-sh
 libtool
@@ -27,6 +28,11 @@ Makefile.objects
 missing
 mkinstalldirs
 modules
+
+# Project
+.idea/
+
+# Tests
 run-tests.php
 tests/*/*.diff
 tests/*/*.out
@@ -35,3 +41,7 @@ tests/*/*.exp
 tests/*/*.log
 tests/*/*.sh
 !tests/utils/*.php
+
+# Code coverage
+jsonpath_lcov.info
+lcov_html/

--- a/Makefile.gcov
+++ b/Makefile.gcov
@@ -1,0 +1,39 @@
+#
+# GCOV
+#
+
+LTP = lcov
+LTP_GENHTML = genhtml
+
+lcov: lcov-html
+
+jsonpath_lcov.info:
+	@echo "Generating lcov data for $@"
+	$(LTP) --capture --no-external --directory . --output-file $@
+
+lcov-html: jsonpath_lcov.info
+	@echo "Generating lcov HTML"
+	$(LTP_GENHTML) --legend --output-directory lcov_html/ --title "JSONPath PHP extension code coverage" jsonpath_lcov.info
+
+lcov-summary: jsonpath_lcov.info
+	$(LTP) --summary jsonpath_lcov.info
+
+lcov-clean:
+	rm -f jsonpath_lcov.info
+	rm -rf lcov_html/
+
+lcov-clean-data:
+	@find . -name \*.gcda -o -name \*.da -o -name \*.bbg? | xargs rm -f
+
+gcovr-html:
+	@echo "Generating gcovr HTML"
+	@rm -rf gcovr_html/
+	@mkdir gcovr_html
+	gcovr -sr . -o gcovr_html/index.html --html --html-details
+
+gcovr-xml:
+	@echo "Generating gcovr XML"
+	@rm -f gcovr.xml
+	gcovr -sr . -o gcovr.xml --xml
+
+.PHONY: gcovr-html lcov-html jsonpath_lcov.info

--- a/config.m4
+++ b/config.m4
@@ -2,9 +2,15 @@ dnl $Id$
 dnl config.m4 for extension jsonpath
 
 PHP_ARG_ENABLE([jsonpath],
-  [whether to enable jsonpath support],
+  [whether to enable JSONPath support],
   [AS_HELP_STRING([--enable-jsonpath],
-    [Enable jsonpath support])]
+    [Enable JSONPath support])]
+  [no])
+
+PHP_ARG_ENABLE([code-coverage],
+  [whether to enable code coverage (relevant for extension development only!)],
+  [AS_HELP_STRING([--enable-code-coverage],
+    [Enable code coverage])]
   [no])
 
 JSONPATH_SOURCES="\
@@ -16,8 +22,37 @@ JSONPATH_SOURCES="\
   ";
 
 if test "$PHP_JSONPATH" != "no"; then
-  AC_DEFINE(HAVE_JSONPATH, 1, [ Have jsonpath support ])
+  AC_DEFINE(HAVE_JSONPATH, 1, [JSONPath support enabled])
   PHP_NEW_EXTENSION(jsonpath, jsonpath.c $JSONPATH_SOURCES, $ext_shared)
   PHP_ADD_BUILD_DIR($ext_builddir/src/jsonpath)
   PHP_ADD_MAKEFILE_FRAGMENT
+fi
+
+if test "$PHP_CODE_COVERAGE" != "no"; then
+  if test "$GCC" != "yes"; then
+    AC_MSG_ERROR([GCC is required for --enable-code-coverage])
+  fi
+
+  dnl Check if ccache is being used.
+  case `$php_shtool path $CC` in
+    *ccache*[)] gcc_ccache=yes;;
+    *[)] gcc_ccache=no;;
+  esac
+
+  if test "$gcc_ccache" = "yes" && (test -z "$CCACHE_DISABLE" || test "$CCACHE_DISABLE" != "1"); then
+    AC_MSG_ERROR([ccache must be disabled when --enable-code-coverage option is used. You can disable ccache by setting environment variable CCACHE_DISABLE=1.])
+  fi
+
+  AC_DEFINE(HAVE_CODE_COVERAGE, 1, [Code coverage enabled])
+  PHP_ADD_MAKEFILE_FRAGMENT($abs_srcdir/Makefile.gcov, $abs_srcdir)
+
+  dnl Remove all optimization flags from CFLAGS.
+  changequote({,})
+  CFLAGS=`echo "$CFLAGS" | "${SED}" -e 's/-O[0-9s]*//g'`
+  CXXFLAGS=`echo "$CXXFLAGS" | "${SED}" -e 's/-O[0-9s]*//g'`
+  changequote([,])
+
+  dnl Add the special gcc flags.
+  CFLAGS="$CFLAGS -O0 -fprofile-arcs -ftest-coverage"
+  CXXFLAGS="$CXXFLAGS -O0 -fprofile-arcs -ftest-coverage"
 fi

--- a/config.w32
+++ b/config.w32
@@ -1,6 +1,6 @@
-ARG_ENABLE('jsonpath', 'enable jsonpath support', 'no');
+ARG_ENABLE('jsonpath', 'enable JSONPath support', 'no');
 
 if (PHP_JSONPATH != 'no') {
-	AC_DEFINE('HAVE_JSONPATH', 1, 'jsonpath support enabled')
+	AC_DEFINE('HAVE_JSONPATH', 1, 'JSONPath support enabled')
 	EXTENSION('jsonpath', 'jsonpath.c', null, '/DZEND_ENABLE_STATIC_TSRMLS_CACHE=1');
 }


### PR DESCRIPTION
This PR adds support for code coverage reports. The extension has to be compiled with the `--enable-code-coverage` flag for the tests to produce the code coverage reports.

Usage:

```
make clean
./configure --enable-jsonpath --enable-code-coverage --with-php-config=...
TEST_PHP_ARGS="-q" make test
make lcov
```

The above results in an HTML report in `lcov_html/`.

Also plugged into the GitHub Actions on merge to `main`, for showing a badge in README.