### PR TITLE
Replace sprintf in lexer, fix 6 tests

### DIFF
--- a/jsonpath.c
+++ b/jsonpath.c
@@ -98,11 +98,10 @@ bool scanTokens(char* json_path, lex_token tok[], char tok_literals[][PARSE_BUF_
   lex_token cur_tok;
   char* p = json_path;
   char buffer[PARSE_BUF_LEN];
-  lex_error err;
 
   int i = 0;
 
-  while ((cur_tok = scan(&p, buffer, sizeof(buffer), &err)) != LEX_NOT_FOUND) {
+  while ((cur_tok = scan(&p, buffer, sizeof(buffer), json_path)) != LEX_NOT_FOUND) {
     if (i >= PARSE_BUF_LEN) {
       zend_throw_exception(spl_ce_RuntimeException, "The query is too long. Token count exceeds PARSE_BUF_LEN.", 0);
       return false;
@@ -115,8 +114,6 @@ bool scanTokens(char* json_path, lex_token tok[], char tok_literals[][PARSE_BUF_
         strcpy(tok_literals[i], buffer);
         break;
       case LEX_ERR:
-        snprintf(err.msg, sizeof(err.msg), "%s at position %ld", err.msg, (err.pos - json_path));
-        zend_throw_exception(spl_ce_RuntimeException, err.msg, 0);
         return false;
       default:
         tok_literals[i][0] = '\0';

--- a/src/jsonpath/interpreter.c
+++ b/src/jsonpath/interpreter.c
@@ -47,7 +47,7 @@ void eval_ast(zval* arr_head, zval* arr_cur, struct ast_node* tok, zval* return_
         return;
       default:
         assert(0);
-        break;
+        return;
     }
   }
 }

--- a/src/jsonpath/lexer.h
+++ b/src/jsonpath/lexer.h
@@ -33,11 +33,6 @@ typedef enum {
 
 extern const char* LEX_STR[];
 
-typedef struct {
-  char* pos; /* The position where lexing stopped */
-  char msg[100];
-} lex_error;
-
-lex_token scan(char** p, char* buffer, size_t bufSize, lex_error* err);
+lex_token scan(char** p, char* buffer, size_t bufSize, char* json_path);
 
 #endif /* LEXER_H */

--- a/tests/comparison_bracket_notation/030.phpt
+++ b/tests/comparison_bracket_notation/030.phpt
@@ -16,8 +16,8 @@ echo "Assertion 1\n";
 var_dump($result);
 ?>
 --EXPECTF--
-Fatal error: Uncaught RuntimeException: Missing closing ] bracket at position %d in %s030.php:%d
+Fatal error: Uncaught RuntimeException: Missing closing ] bracket at position %d in %s
 Stack trace:
-#0 %s030.php(%d): JsonPath->find(Array, '$['single'quote...')
-#1 {main}
-  thrown in %s030.php on line %d
+%s
+%s
+%s

--- a/tests/comparison_bracket_notation/036.phpt
+++ b/tests/comparison_bracket_notation/036.phpt
@@ -24,8 +24,8 @@ echo "Assertion 1\n";
 var_dump($result);
 ?>
 --EXPECTF--
-Fatal error: Uncaught RuntimeException: Missing closing ] bracket at position 7 in %s036.php:%d
+Fatal error: Uncaught RuntimeException: Missing closing ] bracket at position 7 in %s
 Stack trace:
-#0 %s036.php(%d): JsonPath->find(Array, '$['two'.'some']')
-#1 {main}
-  thrown in %s036.php on line %d
+%s
+%s
+%s

--- a/tests/comparison_bracket_notation/046.phpt
+++ b/tests/comparison_bracket_notation/046.phpt
@@ -16,8 +16,8 @@ echo "Assertion 1\n";
 var_dump($result);
 ?>
 --EXPECTF--
-Fatal error: Uncaught RuntimeException: Filter must not be empty in %s046.php:%d
+Fatal error: Uncaught RuntimeException: Unrecognized token 'k' at position 2 in %s
 Stack trace:
-#0 %s046.php(%d): JsonPath->find(Array, '$[key]')
-#1 {main}
-  thrown in %s046.php on line %d
+%s
+%s
+%s

--- a/tests/comparison_dot_notation/003.phpt
+++ b/tests/comparison_dot_notation/003.phpt
@@ -21,8 +21,8 @@ echo "Assertion 1\n";
 var_dump($result);
 ?>
 --EXPECTF--
-Fatal error: Uncaught RuntimeException: Filter must not be empty in %s003.php:%d
+Fatal error: Uncaught RuntimeException: Unrecognized token 'k' at position 3 in %s
 Stack trace:
-#0 %s003.php(%d): JsonPath->find(Array, '$.[key]')
-#1 {main}
-  thrown in %s003.php on line %d
+%s
+%s
+%s

--- a/tests/comparison_dot_notation/050.phpt
+++ b/tests/comparison_dot_notation/050.phpt
@@ -16,7 +16,7 @@ echo "Assertion 1\n";
 var_dump($result);
 ?>
 --EXPECTF--
-Fatal error: Uncaught RuntimeException: The JSONpath contains no valid elements in %s
+Fatal error: Uncaught RuntimeException: Unrecognized token 'k' at position 0 in %s
 Stack trace:
 %s
 %s

--- a/tests/comparison_filter/004.phpt
+++ b/tests/comparison_filter/004.phpt
@@ -29,7 +29,9 @@ $result = $jsonPath->find($data, "$[?(@.key+50==100)]");
 echo "Assertion 1\n";
 var_dump($result);
 ?>
---EXPECT--
-PHP Fatal Error
---XFAIL--
-Now returns false, would be better to error out due to invalid syntax
+--EXPECTF--
+Fatal error: Uncaught RuntimeException: Unrecognized token '+' at position 9 in %s
+Stack trace:
+%s
+%s
+%s

--- a/tests/comparison_filter/019.phpt
+++ b/tests/comparison_filter/019.phpt
@@ -29,7 +29,9 @@ $result = $jsonPath->find($data, "$[?(@.key/10==5)]");
 echo "Assertion 1\n";
 var_dump($result);
 ?>
---EXPECT--
-PHP Fatal Error
---XFAIL--
-Now returns false, would be better to error out due to invalid syntax
+--EXPECTF--
+Fatal error: Uncaught RuntimeException: Unrecognized token '/' at position 9 in %s
+Stack trace:
+%s
+%s
+%s

--- a/tests/comparison_filter/049.phpt
+++ b/tests/comparison_filter/049.phpt
@@ -29,7 +29,9 @@ $result = $jsonPath->find($data, "$[?(@.d in [2, 3])]");
 echo "Assertion 1\n";
 var_dump($result);
 ?>
---EXPECT--
-PHP Fatal Error
---XFAIL--
-Should error out due to invalid syntax, now get_token_type: Assertion `0' failed
+--EXPECTF--
+Fatal error: Uncaught RuntimeException: Unrecognized token 'i' at position 8 in %s
+Stack trace:
+%s
+%s
+%s

--- a/tests/comparison_filter/050.phpt
+++ b/tests/comparison_filter/050.phpt
@@ -43,7 +43,9 @@ $result = $jsonPath->find($data, "$[?(2 in @.d)]");
 echo "Assertion 1\n";
 var_dump($result);
 ?>
---EXPECT--
-PHP Fatal Error
---XFAIL--
-Should error out due to invalid syntax, now returns the full input array
+--EXPECTF--
+Fatal error: Uncaught RuntimeException: Unrecognized token 'i' at position 6 in %s
+Stack trace:
+%s
+%s
+%s

--- a/tests/comparison_filter/058.phpt
+++ b/tests/comparison_filter/058.phpt
@@ -32,7 +32,9 @@ $result = $jsonPath->find($data, "$[?(@.name=~/@.pattern/)]");
 echo "Assertion 1\n";
 var_dump($result);
 ?>
---EXPECT--
-PHP Fatal Error
---XFAIL--
-Now results in a segfault, would be better to error out due to invalid syntax
+--EXPECTF--
+Fatal error: Uncaught RuntimeException: Unrecognized token '/' at position 12 in %s
+Stack trace:
+%s
+%s
+%s

--- a/tests/comparison_filter/072.phpt
+++ b/tests/comparison_filter/072.phpt
@@ -25,7 +25,9 @@ $result = $jsonPath->find($data, "$[?(null)]");
 echo "Assertion 1\n";
 var_dump($result);
 ?>
---EXPECT--
-PHP Fatal Error
---XFAIL--
-Now results in a segfault, would be better to error out due to invalid syntax
+--EXPECTF--
+Fatal error: Uncaught RuntimeException: Unrecognized token 'n' at position 4 in %s
+Stack trace:
+%s
+%s
+%s

--- a/tests/comparison_misc/002.phpt
+++ b/tests/comparison_misc/002.phpt
@@ -18,7 +18,7 @@ echo "Assertion 1\n";
 var_dump($result);
 ?>
 --EXPECTF--
-Fatal error: Uncaught RuntimeException: $ must be followed by a child selector, filter or recurse element. in %s
+Fatal error: Uncaught RuntimeException: Unrecognized token 'k' at position 2 in %s
 Stack trace:
 %s
 %s

--- a/tests/lex_errs/001.phpt
+++ b/tests/lex_errs/001.phpt
@@ -7,10 +7,10 @@ Ensure exception is thrown for missing closing bracket
 
 $jsonPath = new JsonPath();
 
-try {
-    $jsonPath->find([], "$.testl['test'");
-} catch(RuntimeException $e) {
-    echo get_class($e) . ": " . $e->getMessage();
-}
---EXPECT--
-RuntimeException: Missing closing ] bracket at position 14
+$jsonPath->find([], "$.testl['test'");
+--EXPECTF--
+Fatal error: Uncaught RuntimeException: Missing closing ] bracket at position 14 in %s
+Stack trace:
+%s
+%s
+%s

--- a/tests/lex_errs/002.phpt
+++ b/tests/lex_errs/002.phpt
@@ -7,10 +7,10 @@ Ensure exception is thrown for missing closing bracket
 
 $jsonPath = new JsonPath();
 
-try {
-    $jsonPath->find([], '$.testl["test"');
-} catch(RuntimeException $e) {
-    echo get_class($e) . ": " . $e->getMessage();
-}
---EXPECT--
-RuntimeException: Missing closing ] bracket at position 14
+$jsonPath->find([], '$.testl["test"');
+--EXPECTF--
+Fatal error: Uncaught RuntimeException: Missing closing ] bracket at position 14 in %s
+Stack trace:
+%s
+%s
+%s

--- a/tests/lex_errs/003.phpt
+++ b/tests/lex_errs/003.phpt
@@ -7,10 +7,10 @@ Ensure exception is thrown for missing equals sign for != operator
 
 $jsonPath = new JsonPath();
 
-try {
-    $jsonPath->find([], '$.book[?(@.id.isbn ! "684832674" || @.author == "Herman Melville")]');
-} catch(RuntimeException $e) {
-    echo get_class($e) . ": " . $e->getMessage();
-}
---EXPECT--
-RuntimeException: ! operator missing = at position 20
+$jsonPath->find([], '$.book[?(@.id.isbn ! "684832674" || @.author == "Herman Melville")]');
+--EXPECTF--
+Fatal error: Uncaught RuntimeException: ! operator missing = at position 20 in %s
+Stack trace:
+%s
+%s
+%s

--- a/tests/lex_errs/004.phpt
+++ b/tests/lex_errs/004.phpt
@@ -7,10 +7,10 @@ Ensure exception is thrown for missing double &&
 
 $jsonPath = new JsonPath();
 
-try {
-    $jsonPath->find([], '$.book[?(@.id.isbn == "684832674" & @.author == "Herman Melville")]');
-} catch(RuntimeException $e) {
-    echo get_class($e) . ": " . $e->getMessage();
-}
---EXPECT--
-RuntimeException: 'And' operator must be double && at position 35
+$jsonPath->find([], '$.book[?(@.id.isbn == "684832674" & @.author == "Herman Melville")]');
+--EXPECTF--
+Fatal error: Uncaught RuntimeException: 'And' operator must be double && at position 35 in %s
+Stack trace:
+%s
+%s
+%s

--- a/tests/lex_errs/005.phpt
+++ b/tests/lex_errs/005.phpt
@@ -7,10 +7,10 @@ Ensure exception is thrown for missing double ||
 
 $jsonPath = new JsonPath();
 
-try {
-    $jsonPath->find([], '$.book[?(@.id.isbn == "684832674" | @.author == "Herman Melville")]');
-} catch(RuntimeException $e) {
-    echo get_class($e) . ": " . $e->getMessage();
-}
---EXPECT--
-RuntimeException: 'Or' operator must be double || at position 35
+$jsonPath->find([], '$.book[?(@.id.isbn == "684832674" | @.author == "Herman Melville")]');
+--EXPECTF--
+Fatal error: Uncaught RuntimeException: 'Or' operator must be double || at position 35 in %s
+Stack trace:
+%s
+%s
+%s

--- a/tests/overflow/001.phpt
+++ b/tests/overflow/001.phpt
@@ -1,5 +1,5 @@
 --TEST--
-Ensure order of operations are enforced
+Ensure selector name string length does not exceed buffer
 --SKIPIF--
 <?php if (!extension_loaded("jsonpath")) print "skip"; ?>
 --FILE--
@@ -7,10 +7,10 @@ Ensure order of operations are enforced
 
 $jsonPath = new JsonPath();
 
-try {
-    var_dump($jsonPath->find([], '$.test[?(@.aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa == "true")]'));
-} catch(RuntimeException $e) {
-    echo get_class($e) . ": " . $e->getMessage();
-}
---EXPECT--
-RuntimeException: String size exceeded 50 bytes at position 143
+var_dump($jsonPath->find([], '$.test[?(@.aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa == "true")]'));
+--EXPECTF--
+Fatal error: Uncaught RuntimeException: String exceeded buffer size at position 61 in %s
+Stack trace:
+%s
+%s
+%s


### PR DESCRIPTION
@crocodele I'm planning to eventually remove all usage of legacy C string functions. This PR is a first pass at removing `strcpy` in the lexer.

The lexer now fails when it encounters an unknown character. As a result, 6 additional tests now pass.