### PR TITLE
Fix tests/comparison_union/{012,013}.phpt

### DIFF
--- a/jsonpath.c
+++ b/jsonpath.c
@@ -61,12 +61,12 @@ PHP_METHOD(JsonPath, find) {
 
   /* assemble an array of query execution instructions from parsed tokens */
 
-  parse_error p_err;
   struct ast_node head;
   int i = 0;
 
-  if (!build_parse_tree(lex_tok, lex_tok_literals, &i, lex_tok_count, &head, &p_err)) {
-    zend_throw_exception(spl_ce_RuntimeException, p_err.msg, 0);
+  if (!build_parse_tree(lex_tok, lex_tok_literals, &i, lex_tok_count, &head)) {
+    free_ast_nodes(head.next);
+    return;
   }
 
   if (!validate_parse_tree(head.next)) {

--- a/src/jsonpath/lexer.c
+++ b/src/jsonpath/lexer.c
@@ -261,7 +261,8 @@ lex_token scan(char** p, char* buffer, size_t bufSize, char* json_path) {
       case ' ':
         break;
       default:
-        zend_throw_exception_ex(spl_ce_RuntimeException, 0, "Unrecognized token '%c' at position %ld", **p, (*p - json_path));
+        zend_throw_exception_ex(spl_ce_RuntimeException, 0, "Unrecognized token '%c' at position %ld", **p,
+                                (*p - json_path));
         return LEX_ERR;
     }
 

--- a/src/jsonpath/parser.h
+++ b/src/jsonpath/parser.h
@@ -71,12 +71,8 @@ struct ast_node {
   union ast_node_data data;
 };
 
-typedef struct {
-  char msg[PARSE_BUF_LEN];
-} parse_error;
-
 bool build_parse_tree(lex_token lex_tok[PARSE_BUF_LEN], char lex_tok_values[][PARSE_BUF_LEN], int* lex_idx,
-                      int lex_tok_count, struct ast_node* head, parse_error* err);
+                      int lex_tok_count, struct ast_node* head);
 bool sanity_check(lex_token lex_tok[], int lex_tok_count);
 void free_ast_nodes(struct ast_node* head);
 bool validate_parse_tree(struct ast_node* head);

--- a/tests/comparison_union/012.phpt
+++ b/tests/comparison_union/012.phpt
@@ -24,7 +24,9 @@ $result = $jsonPath->find($data, "$.*[0,:5]");
 echo "Assertion 1\n";
 var_dump($result);
 ?>
---EXPECT--
-PHP Fatal Error
---XFAIL--
-Now returns a bunch of values, would be better to error out due to invalid syntax
+--EXPECTF--
+Fatal error: Uncaught RuntimeException: Multiple filter list separators found [,:], only one type is allowed. in %s
+Stack trace:
+%s
+%s
+%s

--- a/tests/comparison_union/013.phpt
+++ b/tests/comparison_union/013.phpt
@@ -19,7 +19,9 @@ $result = $jsonPath->find($data, "$[1:3,4]");
 echo "Assertion 1\n";
 var_dump($result);
 ?>
---EXPECT--
-PHP Fatal Error
---XFAIL--
-Now returns a bunch of values, would be better to error out due to invalid syntax
+--EXPECTF--
+Fatal error: Uncaught RuntimeException: Multiple filter list separators found [,:], only one type is allowed. in %s
+Stack trace:
+%s
+%s
+%s


### PR DESCRIPTION
@crocodele Throw an exception when expression filter list contains different separate types. Also remove legacy `strncpy()` from parser. Fixes two tests.