### PR TITLE
Fix tests/comparison_recursive_descent/{001,002}.phpt

### DIFF
--- a/src/jsonpath/lexer.c
+++ b/src/jsonpath/lexer.c
@@ -261,7 +261,8 @@ lex_token scan(char** p, char* buffer, size_t bufSize, char* json_path) {
       case ' ':
         break;
       default:
-        zend_throw_exception_ex(spl_ce_RuntimeException, 0, "Unrecognized token '%c' at position %ld", **p, (*p - json_path));
+        zend_throw_exception_ex(spl_ce_RuntimeException, 0, "Unrecognized token '%c' at position %ld", **p,
+                                (*p - json_path));
         return LEX_ERR;
     }
 

--- a/src/jsonpath/parser.c
+++ b/src/jsonpath/parser.c
@@ -440,6 +440,13 @@ bool validate_parse_tree(struct ast_node* head) {
           return false;
         }
         break;
+      case AST_RECURSE:
+        if (cur->next == NULL || (cur->next->type == AST_SELECTOR && cur->next->data.d_selector.value[0] == '\0')) {
+          zend_throw_exception(spl_ce_RuntimeException,
+                               "Recursive descent operator (..) must be followed by a child selector, filter or wildcard.", 0);
+          return false;
+        }
+        break;
       default:
         break;
     }

--- a/tests/comparison_recursive_descent/001.phpt
+++ b/tests/comparison_recursive_descent/001.phpt
@@ -23,7 +23,9 @@ $result = $jsonPath->find($data, "$..");
 echo "Assertion 1\n";
 var_dump($result);
 ?>
---EXPECT--
-PHP Fatal Error
---XFAIL--
-Now returns false, would be better to error out due to invalid syntax
+--EXPECTF--
+Fatal error: Uncaught RuntimeException: Recursive descent operator (..) must be followed by a child selector, filter or wildcard. in %s
+Stack trace:
+%s
+%s
+%s

--- a/tests/comparison_recursive_descent/002.phpt
+++ b/tests/comparison_recursive_descent/002.phpt
@@ -22,7 +22,9 @@ $result = $jsonPath->find($data, "$.key..");
 echo "Assertion 1\n";
 var_dump($result);
 ?>
---EXPECT--
-PHP Fatal Error
---XFAIL--
-Now returns false, would be better to error out due to invalid syntax
+--EXPECTF--
+Fatal error: Uncaught RuntimeException: Recursive descent operator (..) must be followed by a child selector, filter or wildcard. in %s
+Stack trace:
+%s
+%s
+%s


### PR DESCRIPTION
Throw exception when recursive descent operator is empty. Fixes two tests.