### PR TITLE
Require non-empty selector after recursive descent

### DIFF
--- a/src/jsonpath/parser.c
+++ b/src/jsonpath/parser.c
@@ -440,6 +440,13 @@ bool validate_parse_tree(struct ast_node* head) {
           return false;
         }
         break;
+      case AST_RECURSE:
+        if (cur->next == NULL || (cur->next->type == AST_SELECTOR && cur->next->data.d_selector.value[0] == '\0')) {
+          zend_throw_exception(spl_ce_RuntimeException,
+                               "Recursive descent operator (..) must be followed by a child selector, filter or wildcard.", 0);
+          return false;
+        }
+        break;
       default:
         break;
     }

--- a/tests/comparison_dot_notation/023.phpt
+++ b/tests/comparison_dot_notation/023.phpt
@@ -34,7 +34,9 @@ $result = $jsonPath->find($data, '$.."key"');
 echo "Assertion 1\n";
 var_dump($result);
 ?>
---EXPECT--
-PHP Fatal Error
---XFAIL--
-Now returns false, would be better to error out due to invalid syntax
+--EXPECTF--
+Fatal error: Uncaught RuntimeException: Recursive descent operator (..) must be followed by a child selector, filter or wildcard. in %s
+Stack trace:
+%s
+%s
+%s

--- a/tests/comparison_dot_notation/036.phpt
+++ b/tests/comparison_dot_notation/036.phpt
@@ -34,7 +34,9 @@ $result = $jsonPath->find($data, "$..'key'");
 echo "Assertion 1\n";
 var_dump($result);
 ?>
---EXPECT--
-PHP Fatal Error
---XFAIL--
-Now returns false, would be better to error out due to invalid syntax
+--EXPECTF--
+Fatal error: Uncaught RuntimeException: Recursive descent operator (..) must be followed by a child selector, filter or wildcard. in %s
+Stack trace:
+%s
+%s
+%s

--- a/tests/comparison_recursive_descent/001.phpt
+++ b/tests/comparison_recursive_descent/001.phpt
@@ -23,7 +23,9 @@ $result = $jsonPath->find($data, "$..");
 echo "Assertion 1\n";
 var_dump($result);
 ?>
---EXPECT--
-PHP Fatal Error
---XFAIL--
-Now returns false, would be better to error out due to invalid syntax
+--EXPECTF--
+Fatal error: Uncaught RuntimeException: Recursive descent operator (..) must be followed by a child selector, filter or wildcard. in %s
+Stack trace:
+%s
+%s
+%s

--- a/tests/comparison_recursive_descent/002.phpt
+++ b/tests/comparison_recursive_descent/002.phpt
@@ -22,7 +22,9 @@ $result = $jsonPath->find($data, "$.key..");
 echo "Assertion 1\n";
 var_dump($result);
 ?>
---EXPECT--
-PHP Fatal Error
---XFAIL--
-Now returns false, would be better to error out due to invalid syntax
+--EXPECTF--
+Fatal error: Uncaught RuntimeException: Recursive descent operator (..) must be followed by a child selector, filter or wildcard. in %s
+Stack trace:
+%s
+%s
+%s


### PR DESCRIPTION
@crocodele Throw an exception if a recursive descent operator is followed by an empty selector.

Note that in the case of `$..'key'`, the lexer stops reading the selector label once it hits the first `'`, hence why the selector is considered empty.