### PR TITLE
Implement strict type+value checks, fix bool vals

### DIFF
--- a/jsonpath.c
+++ b/jsonpath.c
@@ -111,6 +111,7 @@ bool scanTokens(char* json_path, lex_token tok[], char tok_literals[][PARSE_BUF_
       case LEX_NODE:
       case LEX_LITERAL:
       case LEX_LITERAL_BOOL:
+      case LEX_LITERAL_NUMERIC:
         strcpy(tok_literals[i], buffer);
         break;
       case LEX_ERR:

--- a/src/jsonpath/interpreter.c
+++ b/src/jsonpath/interpreter.c
@@ -253,8 +253,14 @@ zval* operand_to_zval(struct ast_node* src, zval* tmp_dest, zval* arr_head, zval
     case AST_BOOL:
       ZVAL_BOOL(tmp_dest, src->data.d_value.head->data.d_literal.value_bool);
       return tmp_dest;
+    case AST_DOUBLE:
+      ZVAL_DOUBLE(tmp_dest, src->data.d_value.head->data.d_double.value);
+      return tmp_dest;
     case AST_LITERAL:
       ZVAL_STRING(tmp_dest, src->data.d_value.head->data.d_literal.value);
+      return tmp_dest;
+    case AST_LONG:
+      ZVAL_LONG(tmp_dest, src->data.d_value.head->data.d_long.value);
       return tmp_dest;
     case AST_ROOT:
       ZVAL_INDIRECT(tmp_dest, NULL);
@@ -314,7 +320,7 @@ bool evaluate_subexpression(zval* arr_head, zval* arr_cur, enum ast_type operato
 
   switch (operator_type) {
     case AST_EQ:
-      ret = compare(val_lh, val_rh) == 0;
+      ret = fast_is_identical_function(val_lh, val_rh);
       break;
     case AST_NE:
       ret = compare(val_lh, val_rh) != 0;

--- a/src/jsonpath/lexer.h
+++ b/src/jsonpath/lexer.h
@@ -4,31 +4,32 @@
 #include <stddef.h>
 
 typedef enum {
-  LEX_NOT_FOUND,    /* Token not found */
-  LEX_ROOT,         /* $ */
-  LEX_CUR_NODE,     /* @ */
-  LEX_WILD_CARD,    /* * */
-  LEX_DEEP_SCAN,    /* .. */
-  LEX_NODE,         /* .child, ['child'] */
-  LEX_EXPR_END,     /* ] */
-  LEX_SLICE,        /* : */
-  LEX_CHILD_SEP,    /* , */
-  LEX_EXPR_START,   /* ? */
-  LEX_EQ,           /* == */
-  LEX_NEQ,          /* != */
-  LEX_LT,           /* < */
-  LEX_LTE,          /* <= */
-  LEX_GT,           /* > */
-  LEX_GTE,          /* >= */
-  LEX_RGXP,         /* =~ */
-  LEX_PAREN_OPEN,   /* ( */
-  LEX_PAREN_CLOSE,  /* ) */
-  LEX_LITERAL,      /* "some string" 'some string' */
-  LEX_LITERAL_BOOL, /* true, false */
-  LEX_FILTER_START, /* [ */
-  LEX_AND,          /* && */
-  LEX_OR,           /* || */
-  LEX_ERR           /* Signals lexing error */
+  LEX_NOT_FOUND,       /* Token not found */
+  LEX_ROOT,            /* $ */
+  LEX_CUR_NODE,        /* @ */
+  LEX_WILD_CARD,       /* * */
+  LEX_DEEP_SCAN,       /* .. */
+  LEX_NODE,            /* .child, ['child'] */
+  LEX_EXPR_END,        /* ] */
+  LEX_SLICE,           /* : */
+  LEX_CHILD_SEP,       /* , */
+  LEX_EXPR_START,      /* ? */
+  LEX_EQ,              /* == */
+  LEX_NEQ,             /* != */
+  LEX_LT,              /* < */
+  LEX_LTE,             /* <= */
+  LEX_GT,              /* > */
+  LEX_GTE,             /* >= */
+  LEX_RGXP,            /* =~ */
+  LEX_PAREN_OPEN,      /* ( */
+  LEX_PAREN_CLOSE,     /* ) */
+  LEX_LITERAL,         /* "some string" 'some string' */
+  LEX_LITERAL_BOOL,    /* true, false */
+  LEX_LITERAL_NUMERIC, /* int, float */
+  LEX_FILTER_START,    /* [ */
+  LEX_AND,             /* && */
+  LEX_OR,              /* || */
+  LEX_ERR              /* Signals lexing error */
 } lex_token;
 
 extern const char* LEX_STR[];

--- a/src/jsonpath/parser.h
+++ b/src/jsonpath/parser.h
@@ -18,6 +18,7 @@ typedef enum {
 enum ast_type {
   AST_AND,
   AST_BOOL,
+  AST_DOUBLE,
   AST_EQ,
   AST_EXPR,
   AST_GT,
@@ -25,8 +26,8 @@ enum ast_type {
   AST_INDEX_LIST,
   AST_INDEX_SLICE,
   AST_ISSET,
-  AST_LITERAL_BOOL,
   AST_LITERAL,
+  AST_LONG,
   AST_LT,
   AST_LTE,
   AST_NE,
@@ -63,6 +64,12 @@ union ast_node_data {
   struct {
     struct ast_node* head;
   } d_value;
+  struct {
+    double value;
+  } d_double;
+  struct {
+    long value;
+  } d_long;
 };
 
 struct ast_node {

--- a/tests/comparison_filter/032.phpt
+++ b/tests/comparison_filter/032.phpt
@@ -32,5 +32,3 @@ array(1) {
     int(44)
   }
 }
---XFAIL--
-Requires more work on filter expressions

--- a/tests/comparison_filter/033.phpt
+++ b/tests/comparison_filter/033.phpt
@@ -59,5 +59,3 @@ array(1) {
     bool(false)
   }
 }
---XFAIL--
-Requires more work on filter expressions

--- a/tests/comparison_filter/038.phpt
+++ b/tests/comparison_filter/038.phpt
@@ -41,5 +41,3 @@ array(1) {
     float(-12.3)
   }
 }
---XFAIL--
-Requires more work on filter expressions

--- a/tests/comparison_filter/039.phpt
+++ b/tests/comparison_filter/039.phpt
@@ -38,5 +38,3 @@ array(1) {
     int(10)
   }
 }
---XFAIL--
-Requires more work on filter expressions

--- a/tests/comparison_filter/041.phpt
+++ b/tests/comparison_filter/041.phpt
@@ -74,5 +74,3 @@ array(1) {
     string(5) "value"
   }
 }
---XFAIL--
-Requires more work on filter expressions

--- a/tests/comparison_filter/045.phpt
+++ b/tests/comparison_filter/045.phpt
@@ -59,5 +59,3 @@ array(1) {
     bool(true)
   }
 }
---XFAIL--
-Outcome depends on how values of different types are compared


### PR DESCRIPTION
@crocodele I originally set out to fix just #53, but ended up implementing strict type and value checks in expressions (equivalent to `===` comparison in PHP I believe).

The nice thing here is that we're leveraging PHP's internal logic for doing numeric string conversion. The engine now parses long and double (including exponent notation) the same way PHP does.

These changes fix 6 additional unit tests.