### PR TITLE
Fix incorrect key in expected results for filter expression equals test

### DIFF
--- a/tests/comparison_filter/023.phpt
+++ b/tests/comparison_filter/023.phpt
@@ -82,9 +82,7 @@ Assertion 1
 array(1) {
   [0]=>
   array(1) {
-    [0]=>
+    ["key"]=>
     int(42)
   }
 }
---XFAIL--
-Outcome depends on how values of different types are compared


### PR DESCRIPTION
With the correct key, the test now passes too thanks to the recent changes to the way values are compared.