### PR TITLE
Fix default value for --enable-code-coverage build flag

### DIFF
--- a/config.m4
+++ b/config.m4
@@ -4,13 +4,13 @@ dnl config.m4 for extension jsonpath
 PHP_ARG_ENABLE([jsonpath],
   [whether to enable JSONPath support],
   [AS_HELP_STRING([--enable-jsonpath],
-    [Enable JSONPath support])]
-  [no])
+    [Enable JSONPath support])])
 
 PHP_ARG_ENABLE([code-coverage],
   [whether to enable code coverage (relevant for extension development only!)],
   [AS_HELP_STRING([--enable-code-coverage],
-    [Enable code coverage])]
+    [Enable code coverage])],
+  [no],
   [no])
 
 JSONPATH_SOURCES="\


### PR DESCRIPTION
The code coverage build flag was enabled by default and couldn't be disabled. Now works as expected.

## Enabled

`./configure ... --enable-jsonpath --enable-code-coverage`:

=>
```
checking whether to enable JSONPath support... yes, shared
checking whether to enable code coverage (relevant for extension development only!)... yes
``` 

## Disabled

`./configure ... --enable-jsonpath` or `./configure ... --enable-jsonpath --disable-code-coverage`:

=>
```
checking whether to enable JSONPath support... yes, shared
checking whether to enable code coverage (relevant for extension development only!)... no
```