### PR TITLE
Throw exception on multiplying node with numeric literal

### DIFF
--- a/src/jsonpath/parser.c
+++ b/src/jsonpath/parser.c
@@ -356,6 +356,12 @@ static struct ast_node* parse_primary(PARSER_PARAMS) {
       }
       strcpy(tail->data.d_selector.value, CUR_TOKEN_LITERAL());
       CONSUME_TOKEN();
+
+      if (CUR_TOKEN() == LEX_WILD_CARD) {
+        free_ast_nodes(tail);
+        zend_throw_exception(spl_ce_RuntimeException, "Multiplying node values is not supported.", 0);
+        return NULL;
+      }
     }
 
     /* handle @.node[?(...)] */
@@ -376,6 +382,12 @@ static struct ast_node* parse_primary(PARSER_PARAMS) {
   if (CUR_TOKEN() == LEX_PAREN_OPEN) {
     CONSUME_TOKEN();
     struct ast_node* expr = parse_or(PARSER_ARGS);
+
+    // Abort if parsing the expression resulted in an exception
+    if (expr == NULL) {
+      return NULL;
+    }
+
     if (CUR_TOKEN() == LEX_PAREN_CLOSE) {
       CONSUME_TOKEN();
       return expr;

--- a/src/jsonpath/parser.c
+++ b/src/jsonpath/parser.c
@@ -358,7 +358,7 @@ static struct ast_node* parse_primary(PARSER_PARAMS) {
       CONSUME_TOKEN();
 
       if (CUR_TOKEN() == LEX_WILD_CARD) {
-        free_ast_nodes(tail);
+        free_ast_nodes(ret);
         zend_throw_exception(spl_ce_RuntimeException, "Multiplying node values is not supported.", 0);
         return NULL;
       }

--- a/tests/comparison_filter/053.phpt
+++ b/tests/comparison_filter/053.phpt
@@ -29,7 +29,9 @@ $result = $jsonPath->find($data, "$[?(@.key*2==100)]");
 echo "Assertion 1\n";
 var_dump($result);
 ?>
---EXPECT--
-PHP Fatal Error
---XFAIL--
-Should error out due to invalid syntax, now get_token_type: Assertion `0' failed
+--EXPECTF--
+Fatal error: Uncaught RuntimeException: Multiplying node values is not supported. in %s
+Stack trace:
+%s
+%s
+%s


### PR DESCRIPTION
Relates to https://github.com/supermetrics/php-ext-jsonpath/issues/51.

This is for handling this type of expressions: `$[?(@.key*2==100)]`

Currently the above leads to a `Missing closing paren )` error. By identifying the scenario where a node is followed by a wildcard, we can give a more specific error message.

The implementation feels slightly hacky, but I wasn't sure where else I could/should hook into the parsing steps to handle this.