### PR TITLE
Mark filter with simple equals sign test as fixed

### DIFF
--- a/tests/comparison_filter/061.phpt
+++ b/tests/comparison_filter/061.phpt
@@ -80,7 +80,9 @@ $result = $jsonPath->find($data, "$[?(@.key=42)]");
 echo "Assertion 1\n";
 var_dump($result);
 ?>
---EXPECT--
-PHP Fatal Error
---XFAIL--
-Now returns false, would be better to error out due to invalid syntax
+--EXPECTF--
+Fatal error: Uncaught RuntimeException: Invalid character after '='. Valid values: '==', '!~'. at position 10 in %s
+Stack trace:
+%s
+%s
+%s


### PR DESCRIPTION
This "test filter expression with single equal" test was fixed by https://github.com/supermetrics/php-ext-jsonpath/pull/72, similarly to the triple equal sign test.