### PR TITLE
Throw exception when parens are missing in filter expression

### DIFF
--- a/tests/comparison_filter/074.phpt
+++ b/tests/comparison_filter/074.phpt
@@ -80,7 +80,9 @@ $result = $jsonPath->find($data, "$[?@.key==42]");
 echo "Assertion 1\n";
 var_dump($result);
 ?>
---EXPECT--
-PHP Fatal Error
---XFAIL--
-Now results in a segfault, would be better to error out due to invalid syntax
+--EXPECTF--
+Fatal error: Uncaught RuntimeException: Missing opening paren ( in %s
+Stack trace:
+%s
+%s
+%s


### PR DESCRIPTION
Relates to https://github.com/supermetrics/php-ext-jsonpath/issues/51.