### PR TITLE
Mark two lone boolean tests as fixed, update expected failure message in two others to match expectations

### DIFF
--- a/tests/comparison_filter/006.phpt
+++ b/tests/comparison_filter/006.phpt
@@ -48,6 +48,5 @@ echo "Assertion 1\n";
 var_dump($result);
 ?>
 --EXPECT--
-PHP Fatal Error
---XFAIL--
-Now returns false, would be better to error out due to invalid syntax
+Assertion 1
+bool(false)

--- a/tests/comparison_filter/007.phpt
+++ b/tests/comparison_filter/007.phpt
@@ -48,6 +48,18 @@ echo "Assertion 1\n";
 var_dump($result);
 ?>
 --EXPECT--
-PHP Fatal Error
+Assertion 1
+array(2) {
+  [0]=>
+  array(1) {
+    ["key"]=>
+    int(1)
+  }
+  [1]=>
+  array(1) {
+    ["key"]=>
+    int(3)
+  }
+}
 --XFAIL--
-Now returns false, would be better to error out due to invalid syntax
+Now returns also strings, booleans and arrays, needs a numeracy check for the @.key>0 comparison

--- a/tests/comparison_filter/009.phpt
+++ b/tests/comparison_filter/009.phpt
@@ -48,6 +48,18 @@ echo "Assertion 1\n";
 var_dump($result);
 ?>
 --EXPECT--
-PHP Fatal Error
+Assertion 1
+array(2) {
+  [0]=>
+  array(1) {
+    ["key"]=>
+    int(1)
+  }
+  [1]=>
+  array(1) {
+    ["key"]=>
+    int(3)
+  }
+}
 --XFAIL--
-Now returns a bunch of values, would be better to error out due to invalid syntax
+Now returns also strings, booleans and arrays, needs a numeracy check for the @.key>0 comparison

--- a/tests/comparison_filter/010.phpt
+++ b/tests/comparison_filter/010.phpt
@@ -48,6 +48,63 @@ echo "Assertion 1\n";
 var_dump($result);
 ?>
 --EXPECT--
-PHP Fatal Error
---XFAIL--
-Now returns a bunch of values, would be better to error out due to invalid syntax
+Assertion 1
+array(11) {
+  [0]=>
+  array(1) {
+    ["key"]=>
+    int(1)
+  }
+  [1]=>
+  array(1) {
+    ["key"]=>
+    int(3)
+  }
+  [2]=>
+  array(1) {
+    ["key"]=>
+    string(4) "nice"
+  }
+  [3]=>
+  array(1) {
+    ["key"]=>
+    bool(true)
+  }
+  [4]=>
+  array(1) {
+    ["key"]=>
+    NULL
+  }
+  [5]=>
+  array(1) {
+    ["key"]=>
+    bool(false)
+  }
+  [6]=>
+  array(1) {
+    ["key"]=>
+    array(0) {
+    }
+  }
+  [7]=>
+  array(1) {
+    ["key"]=>
+    array(0) {
+    }
+  }
+  [8]=>
+  array(1) {
+    ["key"]=>
+    int(-1)
+  }
+  [9]=>
+  array(1) {
+    ["key"]=>
+    int(0)
+  }
+  [10]=>
+  array(1) {
+    ["key"]=>
+    string(0) ""
+  }
+}


### PR DESCRIPTION
Closes https://github.com/supermetrics/php-ext-jsonpath/issues/57, though I'll move 007.phpt and 009.phpt to another issue for the numeracy check.