### PR TITLE
Return false when inequality contains dissimilar operand types

### DIFF
--- a/src/jsonpath/parser.c
+++ b/src/jsonpath/parser.c
@@ -507,7 +507,7 @@ bool validate_expression_head(struct ast_node* tok) {
   if (is_binary(tok->type)) {
     return true;
   }
-  
+
   if (is_unary(tok->type)) {
     return true;
   }

--- a/tests/comparison_filter/007.phpt
+++ b/tests/comparison_filter/007.phpt
@@ -61,5 +61,3 @@ array(2) {
     int(3)
   }
 }
---XFAIL--
-Now returns also strings, booleans and arrays, needs a numeracy check for the @.key>0 comparison

--- a/tests/comparison_filter/009.phpt
+++ b/tests/comparison_filter/009.phpt
@@ -61,5 +61,3 @@ array(2) {
     int(3)
   }
 }
---XFAIL--
-Now returns also strings, booleans and arrays, needs a numeracy check for the @.key>0 comparison

--- a/tests/comparison_filter/047.phpt
+++ b/tests/comparison_filter/047.phpt
@@ -72,5 +72,3 @@ array(3) {
     int(100)
   }
 }
---XFAIL--
-Outcome depends on how values of different types are compared

--- a/tests/comparison_filter/048.phpt
+++ b/tests/comparison_filter/048.phpt
@@ -77,5 +77,3 @@ array(4) {
     int(100)
   }
 }
---XFAIL--
-Outcome depends on how values of different types are compared

--- a/tests/comparison_filter/051.phpt
+++ b/tests/comparison_filter/051.phpt
@@ -77,5 +77,3 @@ array(4) {
     float(41.9999)
   }
 }
---XFAIL--
-Outcome depends on how values of different types are compared

--- a/tests/comparison_filter/052.phpt
+++ b/tests/comparison_filter/052.phpt
@@ -82,5 +82,3 @@ array(5) {
     float(41.9999)
   }
 }
---XFAIL--
-Outcome depends on how values of different types are compared

--- a/tests/comparison_filter/055.phpt
+++ b/tests/comparison_filter/055.phpt
@@ -50,7 +50,6 @@ $data = [
 $jsonPath = new JsonPath();
 $result = $jsonPath->find($data, "$[?(!(@.key<42))]");
 
-echo "Assertion 1\n";
 var_dump($result);
 ?>
 --EXPECT--
@@ -101,5 +100,3 @@ array(9) {
     string(5) "value"
   }
 }
---XFAIL--
-This kind of negation is not currently supported

--- a/tests/comparison_filter/056.phpt
+++ b/tests/comparison_filter/056.phpt
@@ -77,7 +77,6 @@ $data = [
 $jsonPath = new JsonPath();
 $result = $jsonPath->find($data, "$[?(@.key!=42)]");
 
-echo "Assertion 1\n";
 var_dump($result);
 ?>
 --EXPECT--
@@ -189,5 +188,3 @@ array(19) {
     string(5) "value"
   }
 }
---XFAIL--
-Outcome depends on how values of different types are compared (string "42"), fails to include item with missing `key` property


### PR DESCRIPTION
Handle strict inequality checks as described in #59.