### PR TITLE
Fix memory leak on invalid filter expression (missing closing paren)

### DIFF
--- a/src/jsonpath/parser.c
+++ b/src/jsonpath/parser.c
@@ -416,7 +416,7 @@ static struct ast_node* parse_primary(PARSER_PARAMS) {
     CONSUME_TOKEN();
     struct ast_node* expr = parse_or(PARSER_ARGS);
 
-    // Abort if parsing the expression resulted in an exception
+    /* Abort if parsing the expression resulted in an exception */
     if (expr == NULL) {
       return NULL;
     }
@@ -425,6 +425,7 @@ static struct ast_node* parse_primary(PARSER_PARAMS) {
       CONSUME_TOKEN();
       return expr;
     } else {
+      free_ast_nodes(expr);
       zend_throw_exception_ex(spl_ce_RuntimeException, 0, "Missing closing paren )");
       return NULL;
     }


### PR DESCRIPTION
Output of `tests/parse_errs/002.phpt` before:

```
Fatal error: Uncaught RuntimeException: Missing closing paren ) in /..../tests/parse_errs/002.php:5
Stack trace:
#0 /..../tests/parse_errs/002.php(5): JsonPath->find(Array, '$.store.book[?(...')
#1 {main}
  thrown in /..../tests/parse_errs/002.php on line 5
[Thu May 13 02:22:55 2021]  Script:  '/..../tests/parse_errs/002.php'
/..../src/jsonpath/parser.c(55) :  Freeing 0x00007f639205e4d0 (72 bytes), script=/..../tests/parse_errs/002.php
Last leak repeated 2 times
=== Total 3 memory leaks detected ===
```