### PR TITLE
Throw exception on dot or recursive descent operator followed by quoted string

### DIFF
--- a/src/jsonpath/lexer.c
+++ b/src/jsonpath/lexer.c
@@ -91,6 +91,11 @@ lex_token scan(char** p, char* buffer, size_t bufSize, char* json_path) {
         if (found_token == LEX_NODE) {
           (*p)++;
 
+          if (**p == '"' || **p == '\'') {
+            raise_error("Quoted node names must use the bracket notation [", json_path, *p);
+            return LEX_ERR;
+          }
+
           if (!extract_unbounded_literal(*p, buffer, bufSize, json_path)) {
             return LEX_ERR;
           }

--- a/tests/comparison_dot_notation/022.phpt
+++ b/tests/comparison_dot_notation/022.phpt
@@ -16,7 +16,9 @@ $result = $jsonPath->find($data, '$."key"');
 echo "Assertion 1\n";
 var_dump($result);
 ?>
---EXPECT--
-PHP Fatal Error
---XFAIL--
-Now returns false, would be better to error out due to invalid syntax
+--EXPECTF--
+Fatal error: Uncaught RuntimeException: Quoted node names must use the bracket notation [ at position 2 in %s
+Stack trace:
+%s
+%s
+%s

--- a/tests/comparison_dot_notation/023.phpt
+++ b/tests/comparison_dot_notation/023.phpt
@@ -35,7 +35,7 @@ echo "Assertion 1\n";
 var_dump($result);
 ?>
 --EXPECTF--
-Fatal error: Uncaught RuntimeException: Recursive descent operator (..) must be followed by a child selector, filter or wildcard. in %s
+Fatal error: Uncaught RuntimeException: Quoted node names must use the bracket notation [ at position 3 in %s
 Stack trace:
 %s
 %s

--- a/tests/comparison_dot_notation/035.phpt
+++ b/tests/comparison_dot_notation/035.phpt
@@ -16,7 +16,9 @@ $result = $jsonPath->find($data, "$.'key'");
 echo "Assertion 1\n";
 var_dump($result);
 ?>
---EXPECT--
-PHP Fatal Error
---XFAIL--
-Now returns false, would be better to error out due to invalid syntax
+--EXPECTF--
+Fatal error: Uncaught RuntimeException: Quoted node names must use the bracket notation [ at position 2 in %s
+Stack trace:
+%s
+%s
+%s

--- a/tests/comparison_dot_notation/036.phpt
+++ b/tests/comparison_dot_notation/036.phpt
@@ -35,7 +35,7 @@ echo "Assertion 1\n";
 var_dump($result);
 ?>
 --EXPECTF--
-Fatal error: Uncaught RuntimeException: Recursive descent operator (..) must be followed by a child selector, filter or wildcard. in %s
+Fatal error: Uncaught RuntimeException: Quoted node names must use the bracket notation [ at position 3 in %s
 Stack trace:
 %s
 %s

--- a/tests/comparison_dot_notation/037.phpt
+++ b/tests/comparison_dot_notation/037.phpt
@@ -19,7 +19,9 @@ $result = $jsonPath->find($data, "$.'some.key'");
 echo "Assertion 1\n";
 var_dump($result);
 ?>
---EXPECT--
-PHP Fatal Error
---XFAIL--
-Now returns false, would be better to error out due to invalid syntax
+--EXPECTF--
+Fatal error: Uncaught RuntimeException: Quoted node names must use the bracket notation [ at position 2 in %s
+Stack trace:
+%s
+%s
+%s


### PR DESCRIPTION
Closes https://github.com/supermetrics/php-ext-jsonpath/issues/56.