### PR TITLE
Fix Linux build badge image, add Windows build badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # JsonPath-PHP - extension for PHP 8.0+
 
-[![Build status](https://github.com/supermetrics-public/pecl-jsonpath/workflows/Build/badge.svg)](https://github.com/supermetrics-public/pecl-jsonpath/actions?query=workflow%3ABuild)
+[![Linux build status](https://github.com/supermetrics-public/pecl-jsonpath/workflows/Build%20and%20test%20on%20Linux/badge.svg)](https://github.com/supermetrics-public/pecl-jsonpath/actions?query=workflow%3ABuild)
+[![Windows build status](https://github.com/supermetrics-public/pecl-jsonpath/workflows/Build%20and%20test%20on%20Windows/badge.svg)](https://github.com/supermetrics-public/pecl-jsonpath/actions?query=workflow%3ABuild)
 ![Code coverage](https://img.shields.io/endpoint?url=https://gist.githubusercontent.com/crocodele/5ceb08845fe95635fc41af2f4c86c631/raw/pecl-jsonpath__main.json&labelColor=343940)
 
 JSONPath is a language for querying and extracting data from JSON, similar to XPath for XML.


### PR DESCRIPTION
The build badge image URL has been broken ever since the workflow was renamed from "Build" to "Build and test on Linux". Let's fix that.

Also adding a badge for the Windows build.