### PR TITLE
Add support for PHP 8.5 in installation with PIE

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,7 @@
   "license": "PHP-3.01",
   "description": "Extract data from a decoded JSON document using the versatile JSONPath query language",
   "require": {
-    "php": ">=8.0,<8.5"
+    "php": ">=8.0,<8.6"
   },
   "php-ext": {
     "extension-name": "jsonpath",


### PR DESCRIPTION
As the tests now run also on PHP 8.5 in both Linux and Windows in CI, we can officially announce support for PHP 8.5.

Once this is in, I'll release v3.1.0.